### PR TITLE
Rename the binaries generated by the build scripts to differentiate them from standard luvi builds

### DIFF
--- a/recompile-and-run-all-tests.cmd
+++ b/recompile-and-run-all-tests.cmd
@@ -40,3 +40,5 @@ IF %ERRORLEVEL% NEQ 0 EXIT /B 1
 
 REM This is just added for convenience when repeatedly calling the script via CLI
 cd ../../..
+
+move luvi.exe evo-luvi.exe

--- a/recompile-and-run-all-tests.sh
+++ b/recompile-and-run-all-tests.sh
@@ -19,3 +19,5 @@ cd test/extensions/import
 ./test-import-from-compiled-bundle.sh
 
 cd ../../..
+
+mv luvi evo-luvi


### PR DESCRIPTION
It gets confusing if two different executables exist on the same system, and manually renaming the binary is a bit of a hassle.