### PR TITLE
Update the required minimum cmake version to 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.0.0)
 
 if(WIN32)
   set(projects C ASM ASM_MASM)


### PR DESCRIPTION
This fixes the annoying deprecation warning when using the latest cmake release. I don't suppose anyone would use cmake 2 nowadays, considering version 3 was released in 2014... so it should be safe to require at least that.