### PR TITLE
Place CLI arguments in a 1-indexed table

### DIFF
--- a/Runtime/LuaEnvironment/init.lua
+++ b/Runtime/LuaEnvironment/init.lua
@@ -51,7 +51,7 @@ local commands = {
 }
 
 local function version(args)
-  print(string.format("%s %s", args[0], luvi.version))
+  print(string.format("%s %s", args[1], luvi.version))
   print(generateOptionsString())
 end
 
@@ -87,7 +87,7 @@ Examples:
   # Run unit tests for a luvi app using custom main
   $(LUVI) path/to/app -m tests/run.lua
 ]]
-  print((string.gsub(usage, "%$%(LUVI%)", args[0])))
+  print((string.gsub(usage, "%$%(LUVI%)", args[1])))
 end
 
 local Luvi = {}
@@ -129,7 +129,7 @@ end
 function Luvi:ParseCommandLineArguments(args)
 	local bundles = { }
 	local options = {}
-	local appArgs = { [0] = args[0] }
+	local appArgs = {}
 
 	local key
 	for i = 1, #args do

--- a/Runtime/main.c
+++ b/Runtime/main.c
@@ -182,7 +182,7 @@ int main(int argc, char* argv[] ) {
 
   // Pass the command-line arguments to init as a zero-indexed table
   lua_createtable (L, argc, 0);
-  for (index = 0; index < argc; index++) {
+  for (index = 1; index < argc + 1; index++) {
     lua_pushstring(L, argv[index]);
     lua_rawseti(L, -2, index);
   }


### PR DESCRIPTION
Breaking the convention doesn't seem like a good idea, as it has a high chance of tripping users up.

Doing this might be needed to emulate a NodeJS-style ``process`` table, but that's really not a concern here.