### PR TITLE
Remove support for passing combined bundles to the CLI

### DIFF
--- a/Runtime/LuaEnvironment/CLI.lua
+++ b/Runtime/LuaEnvironment/CLI.lua
@@ -1,4 +1,7 @@
-local CLI = {}
+local CLI = {
+	COMBINED_BUNDLES_ERROR = "Merging multiple bundles is no longer supported; " ..
+	"please restructure your application to use a single entry point instead"
+}
 
 function CLI:ParseCommandLineArguments(argumentsVector)
     if type(argumentsVector) ~= "table" then
@@ -41,6 +44,9 @@ function CLI:ParseCommandLineArguments(argumentsVector)
         end
     end
 
+    if #bundles > 1 then
+		error(self.COMBINED_BUNDLES_ERROR, 0)
+	end
     if key then error("Missing value for option: " .. key, 0) end
 
     -- Show help and version by default

--- a/Runtime/LuaEnvironment/CLI.lua
+++ b/Runtime/LuaEnvironment/CLI.lua
@@ -55,7 +55,7 @@ function CLI:ParseCommandLineArguments(argumentsVector)
         options.help = true
     end
 
-    return {bundles = bundles, options = options, appArgs = appArgs}
+    return {appPath = bundles[1] or "", options = options, appArgs = appArgs}
 
 end
 

--- a/Runtime/LuaEnvironment/CLI.spec.lua
+++ b/Runtime/LuaEnvironment/CLI.spec.lua
@@ -17,7 +17,7 @@ describe("ParseCommandLineArguments", function()
 				help = true,
 				version = true,
 			},
-			bundles = {},
+			appPath = "",
 			appArgs = {},
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -63,7 +63,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				version = true,
 			},
-			bundles = {},
+			appPath = "",
 			appArgs = {},
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -75,7 +75,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				version = true,
 			},
-			bundles = {},
+			appPath = "",
 			appArgs = {},
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -87,7 +87,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				help = true,
 			},
-			bundles = {},
+			appPath = "",
 			appArgs = {},
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -99,7 +99,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				help = true,
 			},
-			bundles = {},
+			appPath = "",
 			appArgs = {},
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -117,7 +117,7 @@ describe("ParseCommandLineArguments", function()
 		local expectedCommandInfo = {
 			options = {
 			},
-			bundles = { "wtf.lua" },
+			appPath = "wtf.lua",
 			appArgs = { "something", "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -128,7 +128,7 @@ describe("ParseCommandLineArguments", function()
 		local expectedCommandInfo = {
 			options = {
 			},
-			bundles = { "file1.lua" },
+			appPath = "file1.lua",
 			appArgs = { "something", "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -139,7 +139,7 @@ describe("ParseCommandLineArguments", function()
 		local expectedCommandInfo = {
 			options = {
 			},
-			bundles = { "file1.lua" },
+			appPath = "file1.lua",
 			appArgs = { "something", "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -151,7 +151,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				output = "something.exe",
 			},
-			bundles = { "file1.lua" },
+			appPath = "file1.lua",
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -163,7 +163,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				output = "something.exe",
 			},
-			bundles = { "file1.lua" },
+			appPath = "file1.lua",
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -176,7 +176,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				main = "something.lua",
 			},
-			bundles = { "file1.lua" },
+			appPath = "file1.lua",
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -188,7 +188,7 @@ describe("ParseCommandLineArguments", function()
 			options = {
 				main = "something.lua",
 			},
-			bundles = { "file1.lua" },
+			appPath = "file1.lua",
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)

--- a/Runtime/LuaEnvironment/CLI.spec.lua
+++ b/Runtime/LuaEnvironment/CLI.spec.lua
@@ -24,35 +24,35 @@ describe("ParseCommandLineArguments", function()
 	end)
 
 	it("should raise an error if the --output flag is set but no file path was provided", function()
-		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "-o" })
+		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "-o" })
 		assert.is_false(success)
 		assert.equals("Missing value for option: output", errorMessage)
 
-		success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "--output" })
+		success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "--output" })
 		assert.is_false(success)
 		assert.equals("Missing value for option: output", errorMessage)
 	end)
 
 	it("should raise an error if the --main flag is set but no file path was provided", function()
-		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "-m" })
+		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "-m" })
 		assert.is_false(success)
 		assert.equals("Missing value for option: main", errorMessage)
 
-		success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "--main" })
+		success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "--main" })
 		assert.is_false(success)
 		assert.equals("Missing value for option: main", errorMessage)
 	end)
 
 	it("should raise an error if an invalid flag was passed", function()
-		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "-"} )
+		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "-"} )
 		assert.is_false(success)
 		assert.equals("Unknown flag: -", errorMessage)
 
-		success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "-invalid" })
+		success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "-invalid" })
 		assert.is_false(success)
 		assert.equals("Unknown flag: -invalid", errorMessage)
 
-		success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "--invalid" })
+		success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "--invalid" })
 		assert.is_false(success)
 		assert.equals("Unknown flag: --invalid", errorMessage)
 	end)
@@ -106,7 +106,7 @@ describe("ParseCommandLineArguments", function()
 	end)
 
 	it("should raise an error if a valid flag is set more than once", function()
-		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, nil, { "--help", "--help" })
+		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "--help", "--help" })
 		assert.is_false(success)
 		assert.equals("Duplicate flags: help", errorMessage)
 	end)
@@ -135,35 +135,35 @@ describe("ParseCommandLineArguments", function()
 	end)
 
 	it("should use all arguments before the -- separator as the bundle paths if more than one was set", function()
-		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "file2.lua", "--",  "something", "42"})
+		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "--",  "something", "42"})
 		local expectedCommandInfo = {
 			options = {
 			},
-			bundles = { "file1.lua", "file2.lua" },
+			bundles = { "file1.lua" },
 			appArgs = { "something", "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
 	end)
 
 	it("should use the argument after the --output flag as the executable path", function()
-		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "file2.lua", "--output",  "something.exe", "--", "42"})
+		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "--output",  "something.exe", "--", "42"})
 		local expectedCommandInfo = {
 			options = {
 				output = "something.exe",
 			},
-			bundles = { "file1.lua", "file2.lua" },
+			bundles = { "file1.lua" },
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
 	end)
 
 	it("should use the argument after the -o flag as the executable path", function()
-		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "file2.lua", "-o",  "something.exe", "--", "42"})
+		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "-o",  "something.exe", "--", "42"})
 		local expectedCommandInfo = {
 			options = {
 				output = "something.exe",
 			},
-			bundles = { "file1.lua", "file2.lua" },
+			bundles = { "file1.lua" },
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
@@ -171,27 +171,33 @@ describe("ParseCommandLineArguments", function()
 
 
 	it("should use the argument after the --main flag as the executable path", function()
-		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "file2.lua", "--main",  "something.lua", "--", "42"})
+		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "--main",  "something.lua", "--", "42"})
 		local expectedCommandInfo = {
 			options = {
 				main = "something.lua",
 			},
-			bundles = { "file1.lua", "file2.lua" },
+			bundles = { "file1.lua" },
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
 	end)
 
 	it("should use the argument after the -m flag as the entry point", function()
-		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "file2.lua", "-m",  "something.lua", "--", "42"})
+		local commandInfo = CLI:ParseCommandLineArguments({ "file1.lua", "-m",  "something.lua", "--", "42"})
 		local expectedCommandInfo = {
 			options = {
 				main = "something.lua",
 			},
-			bundles = { "file1.lua", "file2.lua" },
+			bundles = { "file1.lua" },
 			appArgs = { "42" },
 		}
 		assert.same(expectedCommandInfo, commandInfo)
+	end)
+
+	it("should raise an error if multiple bundle paths were passed", function()
+		local success, errorMessage = pcall(CLI.ParseCommandLineArguments, CLI, { "script.lua", "anotherFile.zip" })
+		assert.is_false(success)
+		assert.equals(CLI.COMBINED_BUNDLES_ERROR, errorMessage)
 	end)
 
 end)

--- a/Runtime/LuaEnvironment/init.lua
+++ b/Runtime/LuaEnvironment/init.lua
@@ -50,11 +50,11 @@ function Luvi:LuaMain(commandLineArgumentsPassedFromC)
 
 	-- Build the app if output is given
 	if commandInfo.options.output then
-		return buildBundle(commandInfo.options.output, makeBundle(commandInfo.bundles))
+		return buildBundle(commandInfo.options.output, makeBundle({ commandInfo.appPath }))
 	end
 
 	-- Run the luvi app with the extra args
-	return commonBundle(commandInfo.bundles, commandInfo.options.main, commandInfo.appArgs)
+	return commonBundle({ commandInfo.appPath }, commandInfo.options.main, commandInfo.appArgs)
 end
 
 function Luvi:IsZipApp(filePath)


### PR DESCRIPTION
See commit messages for a rationale, but basically: simplification and purging features I consider of questionable usefulness. Also, moving towards a more straight-forward CLI similar to the ``node`` runtime.

The code for combining bundles is left untouched, as it affects several other issues and urgently needs tests. Basically, it will be dead code after this is merged, which can then be pruned after the other (still relevant) parts are unit tested.