### PR TITLE
 Integrate an adapted version of the C_Networking API from the evo prototype repository

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -58,5 +58,6 @@ globals = {
 	-- evo APIs
 	"C_EventSystem",
 	"C_FileSystem",
+	"C_Networking",
 	"C_Testing",
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,9 @@ lua_add_executable(luvi
   Runtime/LuaEnvironment/namespaces.lua
   Runtime/API/EventSystem/EventListenerMixin.lua
   Runtime/API/EventSystem/C_EventSystem.lua
+  Runtime/Primitives/AsyncHandleMixin.lua
+  Runtime/Primitives/AsyncStreamMixin.lua
+  Runtime/Primitives/AsyncSocketMixin.lua
   Runtime/API/FileSystem/C_FileSystem.lua
   Runtime/API/Testing/Scenario.lua
   Runtime/API/Testing/TestSuite.lua

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,10 @@ lua_add_executable(luvi
   Runtime/API/FileSystem/C_FileSystem.lua
   Runtime/API/Testing/Scenario.lua
   Runtime/API/Testing/TestSuite.lua
+  Runtime/API/Networking/TcpSocket.lua
+  Runtime/API/Networking/TcpClient.lua
+  Runtime/API/Networking/TcpServer.lua
+  Runtime/API/Networking/C_Networking.lua
   Runtime/API/Testing/C_Testing.lua
   ${lpeg_re_lua}
 )

--- a/Runtime/API/EventSystem/EventListenerMixin.lua
+++ b/Runtime/API/EventSystem/EventListenerMixin.lua
@@ -10,19 +10,12 @@ local EventListenerMixin = {
 	registeredEvents = {},
 }
 
-local function createEventListener()
-	return function(self, eventID, payload)
-		DEBUG(eventID .. " triggered")
-	end
-end
-
 function EventListenerMixin:OnEvent(eventID, payload)
-	-- Defer creation of default listeners to allow testing them more easily
 	local defaultListenerName = self:GetDefaultListenerName(eventID)
 	local eventListener = self[defaultListenerName]
 
 	if type(eventListener) ~= "function" then
-		self[defaultListenerName] = createEventListener()
+		return
 	end
 
 	eventListener(self, eventID, payload)

--- a/Runtime/API/EventSystem/EventListenerMixin.lua
+++ b/Runtime/API/EventSystem/EventListenerMixin.lua
@@ -1,3 +1,4 @@
+local format = format
 local ipairs = ipairs
 local string_explode = string.explode
 local string_lower = string.lower
@@ -22,6 +23,20 @@ function EventListenerMixin:OnEvent(eventID, payload)
 end
 
 function EventListenerMixin:RegisterEvent(eventID)
+	if type(eventID) ~= "string" then
+		error("Usage: RegisterEvent(eventID : string)", 0)
+	end
+
+	local eventListenerName = self:GetDefaultListenerName(eventID)
+	local eventListener = self[eventListenerName]
+	if type(eventListener) ~= "function" then
+		error(format("Attempt to register unknown event %s", eventID), 0)
+	end
+
+	if self:IsEventRegistered(eventID) then
+		error(format("Failed to register event %s (already registered)", eventID), 0)
+	end
+
 	C_EventSystem.AddEventListener(eventID, self)
 	self.registeredEvents[eventID] = true
 end

--- a/Runtime/API/Networking/C_Networking.lua
+++ b/Runtime/API/Networking/C_Networking.lua
@@ -1,0 +1,10 @@
+local C_Networking = {
+	TcpSocket = require("TcpSocket"),
+	TcpServer = require("TcpServer"),
+	TcpClient = require("TcpClient"),
+	AsyncHandleMixin = require("AsyncHandleMixin"),
+	AsyncStreamMixin = require("AsyncStreamMixin"),
+	AsyncSocketMixin = require("AsyncSocketMixin"),
+}
+
+return C_Networking

--- a/Runtime/API/Networking/TcpClient.lua
+++ b/Runtime/API/Networking/TcpClient.lua
@@ -1,0 +1,127 @@
+local rawget = rawget
+local setmetatable = setmetatable
+local type = type
+
+local TcpSocket = require("TcpSocket")
+
+local TcpClient = {}
+
+function TcpClient.__index(target, key)
+	if rawget(TcpClient, key) ~= nil then
+		return TcpClient[key]
+	end
+	if TcpSocket[key] ~= nil then
+		return TcpSocket[key]
+	end
+	return rawget(target, key)
+end
+
+function TcpClient:Construct(hostName, port)
+	local instance = TcpSocket(hostName, port)
+
+	setmetatable(instance, self)
+
+	instance:StartConnecting(hostName, port)
+
+	return instance
+end
+
+TcpClient.__call = TcpClient.Construct
+setmetatable(TcpClient, TcpClient)
+
+function TcpClient:StartConnecting()
+	DEBUG("Connecting to tcp://" .. self.hostName .. ":" .. self.port)
+
+	local function onIncomingDataCallback(errorMessage, chunk)
+		if type(errorMessage) == "string" then
+			return self:TCP_SOCKET_ERROR(errorMessage)
+		end
+
+		if chunk then
+			return self:TCP_CHUNK_RECEIVED(chunk)
+		end
+
+		-- Received EOF, i.e., peer sent FIN to signal they're going away
+		self:TCP_SESSION_ENDED()
+	end
+
+	local function onConnectionEstablishedCallback(errorMessage, ...)
+		if type(errorMessage) == "string" then
+			return self:TCP_SOCKET_ERROR(errorMessage)
+		end
+
+		self:TCP_CONNECTION_ESTABLISHED()
+
+		-- This is guaranteed [by libuv] to succeed when called for the first time
+		self:StartReading(onIncomingDataCallback)
+
+		self:TCP_SESSION_STARTED()
+	end
+
+	self:Connect(self.hostName, self.port, onConnectionEstablishedCallback)
+end
+
+function TcpClient:Disconnect()
+	if self:IsClosing() then
+		return
+	end
+
+	local function onCloseHandler()
+		self:TCP_SOCKET_CLOSED()
+	end
+
+	self:StopReading()
+	self:Shutdown() -- Don't use callbacks for the writable end's shutdown; it's largely useless and will be confusing to some
+	self:Close(onCloseHandler)
+end
+
+function TcpClient:Send(chunk)
+	local function onWriteCallback(errorMessage, ...)
+		if type(errorMessage) == "string" then
+			return self:TCP_SOCKET_ERROR(errorMessage)
+		end
+
+		self:TCP_WRITE_SUCCEEDED(chunk)
+	end
+
+	local success, errorMessage = self:Write(chunk, onWriteCallback)
+	if not success then -- Likely: Write failed due to backpressure from the other end (i.e., the write queue is full)
+		-- Since there's no buffer/drain mechanism currently, this is the best we can do
+		self:TCP_WRITE_FAILED(errorMessage, chunk)
+	end
+end
+
+-- Customizable event handlers: These should be overwritten as needed
+function TcpClient:TCP_SOCKET_ERROR(errorMessage)
+	DEBUG("[TcpClient] TCP_SOCKET_ERROR triggered")
+	ERROR(errorMessage)
+
+	if errorMessage ~= "ECANCELED" then
+		-- If cancelled, the handle was already closed by libuv and this will error
+		self:Disconnect()
+	end
+end
+
+function TcpClient:TCP_CONNECTION_ESTABLISHED()
+	DEBUG("[TcpClient] TCP_CONNECTION_ESTABLISHED triggered")
+end
+function TcpClient:TCP_SESSION_STARTED()
+	DEBUG("[TcpClient] TCP_SESSION_STARTED triggered")
+end
+function TcpClient:TCP_WRITE_SUCCEEDED(chunk)
+	DEBUG("[TcpClient] TCP_WRITE_SUCCEEDED triggered", chunk)
+end
+function TcpClient:TCP_WRITE_FAILED(errorMessage, chunk)
+	DEBUG("[TcpClient] TCP_WRITE_FAILED triggered", errorMessage, chunk)
+end
+function TcpClient:TCP_CHUNK_RECEIVED(chunk)
+	DEBUG("[TcpClient] TCP_CHUNK_RECEIVED triggered", chunk)
+end
+function TcpClient:TCP_SESSION_ENDED()
+	DEBUG("[TcpClient] TCP_SESSION_ENDED triggered")
+end
+function TcpClient:TCP_SOCKET_CLOSED()
+	DEBUG("[TcpClient] TCP_SOCKET_CLOSED triggered")
+end
+
+return TcpClient

--- a/Runtime/API/Networking/TcpServer.lua
+++ b/Runtime/API/Networking/TcpServer.lua
@@ -1,0 +1,232 @@
+local uv = require("uv")
+
+local rawget = rawget
+local setmetatable = setmetatable
+local table_count = table.count
+local type = type
+
+local TcpSocket = require("TcpSocket")
+
+local DEFAULT_SERVER_CREATION_OPTIONS = {
+	port = 12345,
+	hostName = "127.0.0.1",
+	-- These are the default values proposed by libuv (internally) as of 19/06/2022
+	backlogQueueSize = 128,
+}
+
+local TcpServer = {
+	port = DEFAULT_SERVER_CREATION_OPTIONS.port,
+	hostName = DEFAULT_SERVER_CREATION_OPTIONS.hostName,
+	backlogQueueSize = DEFAULT_SERVER_CREATION_OPTIONS.backlogQueueSize,
+}
+
+function TcpServer.__index(target, key)
+	if rawget(TcpServer, key) ~= nil then
+		return TcpServer[key]
+	end
+	if TcpSocket[key] ~= nil then
+		return TcpSocket[key]
+	end
+	return rawget(target, key)
+end
+
+function TcpServer:Construct(creationOptions)
+	creationOptions = creationOptions or DEFAULT_SERVER_CREATION_OPTIONS
+	local instance = {
+		handle = uv.new_tcp(),
+		backlogQueueSize = creationOptions.backlogQueueSize or self.backlogQueueSize,
+		hostName = creationOptions.hostName or self.hostName,
+		port = creationOptions.port or self.port,
+		connections = {},
+	}
+
+	setmetatable(instance, self)
+
+	instance:StartListening()
+
+	return instance
+end
+
+TcpServer.__call = TcpServer.Construct
+setmetatable(TcpServer, TcpServer)
+
+function TcpServer:StartListening()
+	DEBUG(
+		"Listening on tcp://"
+			.. self.hostName
+			.. ":"
+			.. self.port
+			.. " (Backlog queue size: "
+			.. self.backlogQueueSize
+			.. ")"
+	)
+
+	local function onIncomingConnectionCallback(errorMessage)
+		if type(errorMessage) == "string" then
+			return self:TCP_SOCKET_ERROR(errorMessage)
+		end
+
+		local client = uv.new_tcp()
+		self:Accept(client)
+
+		self.connections[client] = true
+		self:TCP_CLIENT_CONNECTED(client)
+
+		-- This is guaranteed [by libuv] to succeed when called for the first time
+		self:StartReading(client)
+
+		self:TCP_SESSION_STARTED(client)
+	end
+
+	local success, errorMessage = self:Bind(self.hostName, self.port)
+	if not success then
+		return self:TCP_SOCKET_ERROR(errorMessage)
+	end
+
+	success, errorMessage = self:Listen(self.backlogQueueSize, onIncomingConnectionCallback)
+	if not success then
+		return self:TCP_SOCKET_ERROR(errorMessage)
+	end
+
+	self:TCP_SERVER_STARTED()
+end
+
+function TcpServer:StopListening()
+	DEBUG("Shutting down server at " .. self:GetURL())
+
+	for client in pairs(self.connections) do
+		self:Disconnect(client, "Server is shutting down")
+		self:TCP_SESSION_ENDED(client)
+	end
+
+	self:Close()
+
+	self:TCP_SERVER_STOPPED()
+end
+
+function TcpServer:Send(client, chunk)
+	local success, errorMessage = client:write(chunk, function()
+		self:TCP_WRITE_SUCCEEDED(client, chunk)
+	end)
+
+	if not success then -- Likely: Write failed due to backpressure from the other end (i.e., the write queue is full)
+		-- Since there's no buffer/drain mechanism currently, this is the best we can do
+		self:TCP_WRITE_FAILED(client, errorMessage, chunk)
+	end
+end
+
+function TcpServer:StopReading(client)
+	client:read_stop()
+end
+
+function TcpServer:StartReading(client)
+	client:read_start(function(errorMessage, chunk)
+		if type(errorMessage) == "string" then
+			return self:OnClientReadError(client, errorMessage)
+		end
+
+		if chunk then
+			return self:TCP_CHUNK_RECEIVED(client, chunk)
+		end
+
+		-- EOF = client closed readable side; keeping the socket half-open seems pointless here, so just shut it down
+		self:Disconnect(client, "Client sent EOF")
+
+		self:TCP_SESSION_ENDED(client)
+	end)
+end
+
+function TcpServer:Disconnect(client, reason)
+	reason = reason or "Unknown"
+
+	DEBUG("Ending TCP session with client " .. self:GetClientInfo(client) .. " (Reason: " .. reason .. ")")
+
+	local function onCloseHandler()
+		self:TCP_CLIENT_DISCONNECTED(client, reason)
+	end
+
+	client:shutdown()
+	client:close(onCloseHandler)
+
+	self.connections[client] = nil
+end
+
+function TcpServer:GetNumActiveSessions()
+	return table_count(self.connections)
+end
+
+function TcpServer:GetMaxBacklogSize()
+	return self.backlogQueueSize
+end
+
+function TcpServer:GetPeerName(client)
+	return client:getpeername()
+end
+
+function TcpServer:GetClientInfo(handle)
+	local peerAddressInfo = handle:getpeername()
+
+	if not peerAddressInfo then
+		return transform.bold("<" .. "Socket destroyed or not yet initialized" .. ">")
+	end
+
+	local socketID = peerAddressInfo.family .. "://" .. peerAddressInfo.ip .. ":" .. peerAddressInfo.port
+
+	return transform.bold("<" .. socketID .. ">"), peerAddressInfo
+end
+
+function TcpServer:OnClientReadError(client, errorID)
+	local humanReadableErrorMessage = uv.strerror(errorID)
+
+	self:TCP_CLIENT_READ_ERROR(client, humanReadableErrorMessage)
+
+	self:Disconnect(client, humanReadableErrorMessage)
+	self:TCP_SESSION_ENDED(client)
+end
+
+-- Customizable event handlers: These should be overwritten as needed
+function TcpServer:TCP_CLIENT_CONNECTED(client)
+	DEBUG("[TcpServer] TCP_CLIENT_CONNECTED triggered", self:GetClientInfo(client))
+end
+
+function TcpServer:TCP_SOCKET_ERROR(errorMessage)
+	DEBUG("[TcpServer] TCP_SOCKET_ERROR triggered", errorMessage)
+end
+
+function TcpServer:TCP_SESSION_STARTED(client)
+	DEBUG("[TcpServer] TCP_SESSION_STARTED triggered", self:GetClientInfo(client))
+end
+
+function TcpServer:TCP_SESSION_ENDED(client)
+	DEBUG("[TcpServer] TCP_SESSION_ENDED triggered", self:GetClientInfo(client))
+end
+
+function TcpServer:TCP_CHUNK_RECEIVED(client, chunk)
+	DEBUG("[TcpServer] TCP_CHUNK_RECEIVED triggered", self:GetClientInfo(client), chunk)
+end
+
+function TcpServer:TCP_WRITE_SUCCEEDED(client, chunk)
+	DEBUG("[TcpServer] TCP_WRITE_SUCCEEDED triggered", self:GetClientInfo(client), chunk)
+end
+
+function TcpServer:TCP_WRITE_FAILED(client, errorMessage, chunk)
+	DEBUG("[TcpServer] TCP_WRITE_FAILED triggered", client, errorMessage, chunk)
+end
+
+function TcpServer:TCP_SERVER_STARTED()
+	DEBUG("[TcpServer] TCP_SERVER_STARTED triggered")
+end
+
+function TcpServer:TCP_SERVER_STOPPED()
+	DEBUG("[TcpServer] TCP_SERVER_STOPPED triggered")
+end
+
+function TcpServer:TCP_CLIENT_DISCONNECTED(client, reason)
+	DEBUG("[TcpServer] TCP_CLIENT_DISCONNECTED triggered", self:GetClientInfo(client), reason)
+end
+
+function TcpServer:TCP_CLIENT_READ_ERROR(client, errorMessage)
+	DEBUG("[TcpServer] TCP_CLIENT_READ_ERROR triggered", client, errorMessage)
+end
+
+return TcpServer

--- a/Runtime/API/Networking/TcpSocket.lua
+++ b/Runtime/API/Networking/TcpSocket.lua
@@ -1,0 +1,73 @@
+local uv = require("uv")
+
+local setmetatable = setmetatable
+local type = type
+
+local AsyncHandleMixin = require("AsyncHandleMixin")
+local AsyncStreamMixin = require("AsyncStreamMixin")
+local AsyncSocketMixin = require("AsyncSocketMixin")
+
+local TcpSocket = {
+	DEFAULT_SOCKET_CREATION_OPTIONS = {
+		hostName = "127.0.0.1",
+		port = 12345,
+	},
+}
+
+function TcpSocket:Construct(hostName, port)
+	local instance = {
+		handle = uv.new_tcp(),
+		hostName = hostName or self.DEFAULT_SOCKET_CREATION_OPTIONS.hostName,
+		port = port or self.DEFAULT_SOCKET_CREATION_OPTIONS.port,
+	}
+
+	setmetatable(instance, { __index = self })
+
+	return instance
+end
+
+setmetatable(TcpSocket, { __call = TcpSocket.Construct })
+
+function TcpSocket:SetKeepAliveTime(keepAliveTimeInMilliseconds)
+	if type(keepAliveTimeInMilliseconds) ~= "number" or keepAliveTimeInMilliseconds < 0 then
+		error("Usage: SetKeepAliveTime(keepAliveTimeInMilliseconds : number)", 0)
+		return
+	end
+
+	local enabledFlag = (keepAliveTimeInMilliseconds > 0)
+	self.handle:keepalive(enabledFlag, keepAliveTimeInMilliseconds)
+	if enabledFlag then
+		DEBUG("TCP_KEEPALIVE is now " .. keepAliveTimeInMilliseconds .. " ms for socket at " .. self:GetURL())
+	else
+		DEBUG("TCP_KEEPALIVE is now OFF for socket at " .. self:GetURL())
+	end
+
+	return true
+end
+
+function TcpSocket:GetPort()
+	return self.port
+end
+
+function TcpSocket:GetHostName()
+	return self.hostName
+end
+
+function TcpSocket:GetURL()
+	return "tcp://" .. self.hostName .. ":" .. self.port
+end
+
+mixin(TcpSocket, AsyncHandleMixin, AsyncStreamMixin, AsyncSocketMixin)
+
+function TcpSocket:OnEvent(eventID, ...)
+	DEBUG("[TcpSocket] OnEvent triggered", eventID, ...)
+
+	local eventListener = self[eventID]
+	if not eventListener then
+		return
+	end
+
+	eventListener(self, eventID, ...)
+end
+
+return TcpSocket

--- a/Runtime/API/Networking/TcpSocket.lua
+++ b/Runtime/API/Networking/TcpSocket.lua
@@ -6,6 +6,7 @@ local type = type
 local AsyncHandleMixin = require("AsyncHandleMixin")
 local AsyncStreamMixin = require("AsyncStreamMixin")
 local AsyncSocketMixin = require("AsyncSocketMixin")
+local EventListenerMixin = require("EventListenerMixin")
 
 local TcpSocket = {
 	DEFAULT_SOCKET_CREATION_OPTIONS = {
@@ -57,17 +58,6 @@ function TcpSocket:GetURL()
 	return "tcp://" .. self.hostName .. ":" .. self.port
 end
 
-mixin(TcpSocket, AsyncHandleMixin, AsyncStreamMixin, AsyncSocketMixin)
-
-function TcpSocket:OnEvent(eventID, ...)
-	DEBUG("[TcpSocket] OnEvent triggered", eventID, ...)
-
-	local eventListener = self[eventID]
-	if not eventListener then
-		return
-	end
-
-	eventListener(self, eventID, ...)
-end
+mixin(TcpSocket, AsyncHandleMixin, AsyncStreamMixin, AsyncSocketMixin, EventListenerMixin)
 
 return TcpSocket

--- a/Runtime/LuaEnvironment/namespaces.lua
+++ b/Runtime/LuaEnvironment/namespaces.lua
@@ -11,6 +11,9 @@ local namespaceLoaders = {
 	C_FileSystem = function()
 		return require("C_FileSystem")
 	end,
+	C_Networking = function()
+		return require("C_Networking")
+	end,
 }
 
 return namespaceLoaders

--- a/Runtime/LuaEnvironment/primitives.lua
+++ b/Runtime/LuaEnvironment/primitives.lua
@@ -22,6 +22,11 @@ local primitives = {
 	dump = function()
 		return require("dump")
 	end,
+	["mixins"] = function()
+		require("AsyncHandleMixin")
+		require("AsyncStreamMixin")
+		require("AsyncSocketMixin")
+	end,
 }
 
 return primitives

--- a/Runtime/Primitives/AsyncHandleMixin.lua
+++ b/Runtime/Primitives/AsyncHandleMixin.lua
@@ -1,0 +1,52 @@
+--- Container for the generic uv_handle_t APIs
+local AsyncHandleMixin = {}
+
+function AsyncHandleMixin:IsActive()
+	return self.handle:is_active()
+end
+
+function AsyncHandleMixin:IsClosing()
+	return self.handle:is_closing()
+end
+
+function AsyncHandleMixin:Close()
+	return self.handle:close()
+end
+
+function AsyncHandleMixin:Reference()
+	return self.handle:ref()
+end
+
+function AsyncHandleMixin:Unreference()
+	return self.handle:unref()
+end
+
+function AsyncHandleMixin:HasReference()
+	return self.handle:has_ref()
+end
+
+function AsyncHandleMixin:SetReceiveBufferSize(bufferSizeInBytes)
+	return self.handle:recv_buffer_size(bufferSizeInBytes)
+end
+
+function AsyncHandleMixin:GetReceiveBufferSize()
+	return self.handle:recv_buffer_size()
+end
+
+function AsyncHandleMixin:SetSendBufferSize(bufferSizeInBytes)
+	return self.handle:send_buffer_size(bufferSizeInBytes)
+end
+
+function AsyncHandleMixin:GetSendBufferSize()
+	return self.handle:send_buffer_size()
+end
+
+function AsyncHandleMixin:GetReadOnlyFileDescriptor()
+	return self.handle:fileno()
+end
+
+function AsyncHandleMixin:GetTypeInfo()
+	return self.handle:handle_get_type()
+end
+
+return AsyncHandleMixin

--- a/Runtime/Primitives/AsyncSocketMixin.lua
+++ b/Runtime/Primitives/AsyncSocketMixin.lua
@@ -1,0 +1,44 @@
+--- Container for the generic uv_tcp_t APIs
+local AsyncSocketMixin = {}
+
+function AsyncSocketMixin:Open(...)
+	return self.handle:open(...)
+end
+
+function AsyncSocketMixin:SetNoDelay(...)
+	return self.handle:nodelay(...)
+end
+
+function AsyncSocketMixin:SetKeepAlive(...)
+	return self.handle:keepalive(...)
+end
+
+function AsyncSocketMixin:SetMultiAcceptMode(...)
+	return self.handle:simultaneous_accepts(...)
+end
+
+function AsyncSocketMixin:Bind(...)
+	return self.handle:bind(...)
+end
+
+function AsyncSocketMixin:GetPeerName()
+	return self.handle:getpeername()
+end
+
+function AsyncSocketMixin:GetSocketName()
+	return self.handle:getsockname()
+end
+
+function AsyncSocketMixin:Connect(...)
+	return self.handle:connect(...)
+end
+
+function AsyncSocketMixin:SetWriteQueueSize()
+	return self.handle:write_queue_size()
+end
+
+function AsyncSocketMixin:Reset()
+	return self.handle:close_reset()
+end
+
+return AsyncSocketMixin

--- a/Runtime/Primitives/AsyncStreamMixin.lua
+++ b/Runtime/Primitives/AsyncStreamMixin.lua
@@ -1,0 +1,44 @@
+--- Container for the generic uv_stream_t APIs
+local AsyncStreamMixin = {}
+
+function AsyncStreamMixin:Shutdown()
+	return self.handle:shutdown()
+end
+
+function AsyncStreamMixin:Listen(...)
+	return self.handle:listen(...)
+end
+
+function AsyncStreamMixin:Accept(...)
+	return self.handle:accept(...)
+end
+
+function AsyncStreamMixin:StartReading(...)
+	return self.handle:read_start(...)
+end
+
+function AsyncStreamMixin:StopReading(...)
+	return self.handle:read_stop(...)
+end
+
+function AsyncStreamMixin:Write(...)
+	return self.handle:write(...)
+end
+
+function AsyncStreamMixin:IsReadable()
+	return self.handle:is_readable()
+end
+
+function AsyncStreamMixin:IsWritable()
+	return self.handle:is_writable()
+end
+
+function AsyncStreamMixin:SetBlockingMode(...)
+	return self.handle:stream_set_blocking(...)
+end
+
+function AsyncStreamMixin:GetWriteQueueSize()
+	return self.handle:stream_get_write_queue_size()
+end
+
+return AsyncStreamMixin

--- a/Tests/Runtime/API/EventSystem/EventListenerMixin.spec.lua
+++ b/Tests/Runtime/API/EventSystem/EventListenerMixin.spec.lua
@@ -21,6 +21,8 @@ describe("EventListenerMixin", function()
 			tempObject.isEventPassed = true
 		end
 
+		function tempObject:OnTestEvent(eventID, payload) end
+
 		return tempObject
 	end
 
@@ -43,9 +45,24 @@ describe("EventListenerMixin", function()
 	end)
 
 	describe("RegisterEvent", function()
-		local listener = createNewEventListener()
+		it("should raise an error if a non-string value is passed as the event ID", function()
+			local listener = createNewEventListener()
+			local function codeUnderTest()
+				listener:RegisterEvent(42)
+			end
+			assertThrows(codeUnderTest, "Usage: RegisterEvent(eventID : string)")
+		end)
+
+		it("should raise an error if there exists no event handler function for the given event ID", function()
+			local listener = createNewEventListener()
+			local function codeUnderTest()
+				listener:RegisterEvent("EVENT_THAT_DOES_NOT_EXIST")
+			end
+			assertThrows(codeUnderTest, "Attempt to register unknown event EVENT_THAT_DOES_NOT_EXIST")
+		end)
 
 		it("should add an event listener for the given event", function()
+			local listener = createNewEventListener()
 			listener:RegisterEvent("HELLO_WORLD")
 
 			-- Can't hook the event handlers here, as the'yre stored as function values in the event registry (no lookup)
@@ -65,16 +82,14 @@ describe("EventListenerMixin", function()
 		end)
 
 		it("should raise an error if the event listener has already been registered for the given event", function()
-			EventListenerMixin:RegisterEvent("HELLO_WORLD_EVENT")
+			local listener = createNewEventListener()
+			listener:RegisterEvent("HELLO_WORLD")
 			local function registerDuplicateEvent()
-				EventListenerMixin:RegisterEvent("HELLO_WORLD_EVENT")
+				listener:RegisterEvent("HELLO_WORLD")
 			end
-			assertThrows(
-				registerDuplicateEvent,
-				"Failed to AddEventListener for HELLO_WORLD_EVENT (already registered)"
-			)
+			assertThrows(registerDuplicateEvent, "Failed to register event HELLO_WORLD (already registered)")
 
-			EventListenerMixin:UnregisterEvent("HELLO_WORLD_EVENT")
+			listener:UnregisterEvent("HELLO_WORLD")
 		end)
 	end)
 
@@ -98,28 +113,29 @@ describe("EventListenerMixin", function()
 
 	describe("UnregisterAllEvents", function()
 		local listener = createNewEventListener()
-		listener:RegisterEvent("ASDF")
-		listener:RegisterEvent("HI")
+		listener:RegisterEvent("TEST_EVENT")
+		listener:RegisterEvent("HELLO_WORLD")
 		it("should remove all registered event listeners", function()
-			assertTrue(listener:IsEventRegistered("ASDF"))
-			assertTrue(listener:IsEventRegistered("HI"))
+			assertTrue(listener:IsEventRegistered("TEST_EVENT"))
+			assertTrue(listener:IsEventRegistered("HELLO_WORLD"))
 			listener:UnregisterAllEvents()
-			assertFalse(listener:IsEventRegistered("ASDF"))
-			assertFalse(listener:IsEventRegistered("HI"))
+			assertFalse(listener:IsEventRegistered("TEST_EVENT"))
+			assertFalse(listener:IsEventRegistered("HELLO_WORLD"))
 		end)
 	end)
 
 	describe("IsEventRegistered", function()
-		local listener = createNewEventListener()
 		it("should return false if the given event has not been registered", function()
-			assertFalse(listener:IsEventRegistered("HI"))
+			local listener = createNewEventListener()
+			assertFalse(listener:IsEventRegistered("HELLO_WORLD"))
 		end)
 
 		it("should return true if the given event has been registered", function()
-			listener:RegisterEvent("ASDF")
-			assertTrue(listener:IsEventRegistered("ASDF"))
+			local listener = createNewEventListener()
+			listener:RegisterEvent("HELLO_WORLD")
+			assertTrue(listener:IsEventRegistered("HELLO_WORLD"))
 
-			listener:UnregisterEvent("ASDF")
+			listener:UnregisterEvent("HELLO_WORLD")
 		end)
 	end)
 

--- a/Tests/Runtime/API/Networking/C_Networking.spec.lua
+++ b/Tests/Runtime/API/Networking/C_Networking.spec.lua
@@ -1,0 +1,5 @@
+describe("API: Networking", function()
+	import("./TcpServer.spec.lua")
+	import("./TcpClient.spec.lua")
+	import("./TcpSocket.spec.lua")
+end)

--- a/Tests/Runtime/API/Networking/TcpClient.spec.lua
+++ b/Tests/Runtime/API/Networking/TcpClient.spec.lua
@@ -1,0 +1,40 @@
+local TcpSocket = C_Networking.TcpSocket
+local TcpClient = C_Networking.TcpClient
+
+describe("TcpClient", function()
+	describe("Constructor", function()
+		it("should start connecting immediately if a valid host name and port were passed", function()
+			local function codeUnderTest()
+				TcpClient("127.0.0.1", 23456)
+			end
+			assertFunctionCalls(codeUnderTest, TcpClient, "StartConnecting")
+		end)
+
+		it("should use the default socket creation parameters if any are missing", function()
+			local client = TcpClient()
+			assertEquals(client:GetPort(), TcpSocket.DEFAULT_SOCKET_CREATION_OPTIONS.port)
+			assertEquals(client:GetHostName(), TcpSocket.DEFAULT_SOCKET_CREATION_OPTIONS.hostName)
+		end)
+
+		it("should register prototypes for all customizable event handlers", function()
+			local expectedEventHandlers = {
+				"TCP_CONNECTION_ESTABLISHED",
+				"TCP_CHUNK_RECEIVED",
+				"TCP_WRITE_SUCCEEDED",
+				"TCP_WRITE_FAILED",
+				"TCP_SESSION_STARTED",
+				"TCP_SESSION_ENDED",
+				"TCP_SOCKET_CLOSED",
+				"TCP_SOCKET_ERROR",
+			}
+
+			local client = TcpClient()
+
+			for _, eventID in ipairs(expectedEventHandlers) do
+				assertEquals(type(client[eventID]), "function", "Should register listener for event " .. eventID)
+			end
+
+			client:Disconnect()
+		end)
+	end)
+end)

--- a/Tests/Runtime/API/Networking/TcpServer.spec.lua
+++ b/Tests/Runtime/API/Networking/TcpServer.spec.lua
@@ -1,0 +1,69 @@
+local TcpServer = C_Networking.TcpServer
+
+describe("TcpServer", function()
+	describe("Constructor", function()
+		it("should use the default socket options if none were passed", function()
+			local server = TcpServer()
+			assertEquals(server:GetPort(), TcpServer:GetPort())
+			assertEquals(server:GetHostName(), TcpServer:GetHostName())
+			assertEquals(server:GetMaxBacklogSize(), TcpServer:GetMaxBacklogSize())
+			assertEquals(server:GetURL(), TcpServer:GetURL())
+
+			server:StopListening()
+		end)
+
+		it("should use the socket creation options if any were passed", function()
+			local options = {
+				port = 123,
+				hostName = "0.0.0.0",
+				backlogQueueSize = 42,
+			}
+
+			local server = TcpServer(options)
+			assertEquals(server:GetPort(), options.port)
+			assertEquals(server:GetHostName(), options.hostName)
+			assertEquals(server:GetMaxBacklogSize(), options.backlogQueueSize)
+			assertEquals(server:GetURL(), "tcp://0.0.0.0:123")
+
+			server:StopListening()
+		end)
+
+		it("should register prototypes for all customizable event handlers", function()
+			local expectedEventHandlers = {
+				"TCP_CLIENT_CONNECTED",
+				"TCP_CLIENT_DISCONNECTED",
+				"TCP_CHUNK_RECEIVED",
+				"TCP_WRITE_SUCCEEDED",
+				"TCP_WRITE_FAILED",
+				"TCP_SESSION_STARTED",
+				"TCP_SESSION_ENDED",
+				"TCP_SOCKET_ERROR",
+				"TCP_CLIENT_READ_ERROR",
+				"TCP_SERVER_STARTED",
+				"TCP_SERVER_STOPPED",
+			}
+
+			local server = TcpServer()
+
+			for _, eventID in ipairs(expectedEventHandlers) do
+				assertEquals(type(server[eventID]), "function", "Should register listener for event " .. eventID)
+			end
+
+			server:StopListening()
+		end)
+
+		it("should start listening on the configured host and port immediately", function()
+			local function codeUnderTest()
+				local server = TcpServer()
+				server:StopListening()
+			end
+			assertFunctionCalls(codeUnderTest, TcpServer, "StartListening")
+		end)
+
+		it("should have no active sessions before any client connects", function()
+			local server = TcpServer()
+			assertEquals(server:GetNumActiveSessions(), 0)
+			server:StopListening()
+		end)
+	end)
+end)

--- a/Tests/Runtime/API/Networking/TcpSocket.spec.lua
+++ b/Tests/Runtime/API/Networking/TcpSocket.spec.lua
@@ -1,0 +1,183 @@
+local TcpSocket = C_Networking.TcpSocket
+
+local function assertExportsAPI(socket, exportedApiSurface)
+	local fauxTcpHandle = {} -- Can't spy on userdata calls, so replace it with a table placeholder
+	socket.handle = fauxTcpHandle
+	for name, targetFunctionName in pairs(exportedApiSurface) do
+		socket.handle[targetFunctionName] = function() end -- Will be spied on, functionality doesn't matter
+		assertEquals(type(TcpSocket[name]), "function", "Should export function " .. name)
+		assertFunctionCalls(function()
+			socket[name](socket)
+		end, fauxTcpHandle, targetFunctionName)
+	end
+end
+
+describe("TcpSocket", function()
+	it("should expose libuv's generic uv_tcp_t API", function()
+		local exportedApiSurface = {
+			Open = "open",
+			SetNoDelay = "nodelay",
+			SetKeepAlive = "keepalive",
+			SetMultiAcceptMode = "simultaneous_accepts",
+			Bind = "bind",
+			GetPeerName = "getpeername",
+			GetSocketName = "getsockname",
+			Connect = "connect",
+			SetWriteQueueSize = "write_queue_size",
+			Reset = "close_reset",
+		}
+
+		local socket = TcpSocket()
+		assertExportsAPI(socket, exportedApiSurface)
+	end)
+
+	it("should expose libuv's generic uv_stream_t API", function()
+		local exportedApiSurface = {
+			Shutdown = "shutdown",
+			Listen = "listen",
+			Accept = "accept",
+			StartReading = "read_start",
+			StopReading = "read_stop",
+			Write = "write",
+			IsReadable = "is_readable",
+			IsWritable = "is_writable",
+			SetBlockingMode = "stream_set_blocking",
+			GetWriteQueueSize = "stream_get_write_queue_size",
+		}
+
+		local socket = TcpSocket()
+		assertExportsAPI(socket, exportedApiSurface)
+	end)
+
+	it("should expose libuv's generic uv_handle_t API", function()
+		local exportedApiSurface = {
+			IsActive = "is_active",
+			IsClosing = "is_closing",
+			Close = "close",
+			Reference = "ref",
+			Unreference = "unref",
+			HasReference = "has_ref",
+			SetSendBufferSize = "send_buffer_size",
+			GetSendBufferSize = "send_buffer_size",
+			SetReceiveBufferSize = "recv_buffer_size",
+			GetReceiveBufferSize = "recv_buffer_size",
+			GetReadOnlyFileDescriptor = "fileno",
+			GetTypeInfo = "handle_get_type",
+		}
+		local socket = TcpSocket()
+		assertExportsAPI(socket, exportedApiSurface)
+	end)
+
+	it("should store the host name and port of the underlying socket", function()
+		local socket = TcpSocket("0.0.0.0", 666)
+		assertEquals(socket:GetPort(), 666)
+		assertEquals(socket:GetHostName(), "0.0.0.0")
+		assertEquals(socket:GetURL(), "tcp://0.0.0.0:666")
+	end)
+
+	describe("SetKeepAliveTime", function()
+		local socket = TcpSocket()
+		local expectedErrorMessage = "Usage: SetKeepAliveTime(keepAliveTimeInMilliseconds : number)"
+		it("should fail if the keep alive time passed is not a number", function()
+			assertThrows(function()
+				socket:SetKeepAliveTime(nil)
+			end, expectedErrorMessage)
+			assertThrows(function()
+				socket:SetKeepAliveTime({})
+			end, expectedErrorMessage)
+			assertThrows(function()
+				socket:SetKeepAliveTime(print)
+			end, expectedErrorMessage)
+			assertThrows(function()
+				socket:SetKeepAliveTime("hi")
+			end, expectedErrorMessage)
+		end)
+
+		it("should fail if the keep alive time passed is a negative number", function()
+			assertThrows(function()
+				socket:SetKeepAliveTime(-1)
+			end, expectedErrorMessage)
+			assertThrows(function()
+				socket:SetKeepAliveTime(-100)
+			end, expectedErrorMessage)
+		end)
+
+		it("should forward the TCP_KEEPALIVE setting to the socket if the keepalive time is valid", function()
+			assertEquals(socket:SetKeepAliveTime(42), true)
+
+			local hasForwardedKeepAliveTime = false
+			local hasSetEnabledFlag = false
+
+			local libuvHandle = socket.handle
+			local fauxHandle = {
+				keepalive = function(self, enabledFlag, delayInMilliseconds)
+					hasForwardedKeepAliveTime = delayInMilliseconds == 100
+					hasSetEnabledFlag = enabledFlag == true
+				end,
+			}
+			socket.handle = fauxHandle
+
+			local function codeUnderTest()
+				socket:SetKeepAliveTime(100)
+			end
+
+			assertFunctionCalls(codeUnderTest, socket.handle, "keepalive")
+
+			assertTrue(hasForwardedKeepAliveTime)
+			assertTrue(hasSetEnabledFlag)
+
+			socket.handle = libuvHandle
+		end)
+
+		it("should disable the TCP_KEEPALIVE setting on the socket if the keepalive time is zero", function()
+			assertEquals(socket:SetKeepAliveTime(0), true)
+
+			local hasForwardedKeepAliveTime = false
+			local hasSetEnabledFlag = false
+
+			local libuvHandle = socket.handle
+			local fauxHandle = {
+				keepalive = function(self, enabledFlag, delayInMilliseconds)
+					hasForwardedKeepAliveTime = (delayInMilliseconds == 0)
+					hasSetEnabledFlag = (enabledFlag == false)
+				end,
+			}
+			socket.handle = fauxHandle
+
+			local function codeUnderTest()
+				socket:SetKeepAliveTime(0)
+			end
+
+			assertFunctionCalls(codeUnderTest, socket.handle, "keepalive")
+
+			assertTrue(hasForwardedKeepAliveTime)
+			assertTrue(hasSetEnabledFlag)
+
+			socket.handle = libuvHandle
+		end)
+	end)
+
+	describe("OnEvent", function()
+		local socket = TcpSocket()
+		it("should do nothing if no event listener for the passed event ID was registered", function()
+			local eventID = "DUMMY_EVENT_DOES_NOT_EXIST"
+
+			assertEquals(socket:OnEvent(eventID), nil)
+		end)
+
+		it("should call the registered event listener and pass all arguments if one exists", function()
+			local eventID = "DUMMY_EVENT_DOES_NOT_EXIST"
+
+			local didPassArguments = false
+			socket[eventID] = function(self, event, arg1, ...)
+				didPassArguments = (arg1 == 42) and (event == eventID)
+			end
+
+			local function codeUnderTest()
+				socket:OnEvent(eventID, 42)
+			end
+			assertFunctionCalls(codeUnderTest, socket, eventID)
+			assertTrue(didPassArguments)
+		end)
+	end)
+end)

--- a/Tests/Runtime/API/Networking/TcpSocket.spec.lua
+++ b/Tests/Runtime/API/Networking/TcpSocket.spec.lua
@@ -156,28 +156,4 @@ describe("TcpSocket", function()
 			socket.handle = libuvHandle
 		end)
 	end)
-
-	describe("OnEvent", function()
-		local socket = TcpSocket()
-		it("should do nothing if no event listener for the passed event ID was registered", function()
-			local eventID = "DUMMY_EVENT_DOES_NOT_EXIST"
-
-			assertEquals(socket:OnEvent(eventID), nil)
-		end)
-
-		it("should call the registered event listener and pass all arguments if one exists", function()
-			local eventID = "DUMMY_EVENT_DOES_NOT_EXIST"
-
-			local didPassArguments = false
-			socket[eventID] = function(self, event, arg1, ...)
-				didPassArguments = (arg1 == 42) and (event == eventID)
-			end
-
-			local function codeUnderTest()
-				socket:OnEvent(eventID, 42)
-			end
-			assertFunctionCalls(codeUnderTest, socket, eventID)
-			assertTrue(didPassArguments)
-		end)
-	end)
 end)

--- a/Tests/Runtime/API/Networking/networking-scenarios.lua
+++ b/Tests/Runtime/API/Networking/networking-scenarios.lua
@@ -1,0 +1,9 @@
+local testSuite = C_Testing.TestSuite("Networking API")
+
+local listOfScenarioFilesToLoad = {
+	"./tcp-echo.lua",
+}
+
+testSuite:AddScenarios(listOfScenarioFilesToLoad)
+
+return testSuite

--- a/Tests/Runtime/API/Networking/tcp-echo.lua
+++ b/Tests/Runtime/API/Networking/tcp-echo.lua
@@ -1,0 +1,74 @@
+local scenario = C_Testing.Scenario("TCP echo server")
+
+local TcpServer = C_Networking.TcpServer
+local TcpClient = C_Networking.TcpClient
+
+scenario:GIVEN("A TCP echo server is listening on localhost")
+scenario:WHEN("A TCP client sends some data to the server")
+scenario:THEN("The server should send the same data back to the client")
+
+local hasClientSentMessageToServer = false
+local hasServerReceivedMessage = false
+local hasServerSentResponse = false
+local hasClientReceivedEchoMessage = false
+
+function scenario:OnSetup()
+	local serverOptions = {
+		port = 1234,
+		hostName = "127.0.0.1",
+	}
+	self.server = TcpServer(serverOptions)
+	self.client = TcpClient("127.0.0.1", 1234)
+end
+
+function scenario:OnRun()
+	print("OnRun")
+	local currentThread = coroutine.running()
+	local client = self.client
+
+	function client.TCP_CONNECTION_ESTABLISHED()
+		print("TCP_CONNECTION_ESTABLISHED")
+		client:Send("Hello server!")
+		hasClientSentMessageToServer = true
+	end
+
+	function client.TCP_CHUNK_RECEIVED(_, chunk)
+		print("TCP_CHUNK_RECEIVED")
+		assertEquals(chunk, "Hello server!", "Should receive the same message that was originally sent")
+		hasClientReceivedEchoMessage = true
+		-- The echo test is over, so we can continue with the report
+		coroutine.resume(currentThread)
+	end
+
+	local server = self.server
+	function server.TCP_CHUNK_RECEIVED(serverSocket, clientSocket, chunk)
+		print("TCP_CHUNK_RECEIVED")
+		assertEquals(chunk, "Hello server!")
+		hasServerReceivedMessage = true
+		serverSocket:Send(clientSocket, chunk)
+	end
+
+	function server.TCP_WRITE_SUCCEEDED()
+		print("TCP_WRITE_SUCCEEDED")
+		hasServerSentResponse = true
+	end
+
+	-- Hand off control to libuv to let async requests complete
+	coroutine.yield()
+end
+
+function scenario:OnEvaluate()
+	print("OnEvaluate")
+	assertTrue(hasClientSentMessageToServer, "The client should have sent a message to the server")
+	assertTrue(hasServerReceivedMessage, "The server should have received the client's message")
+	assertTrue(hasServerSentResponse, "The server should have sent a response")
+	assertTrue(hasClientReceivedEchoMessage, "The client should have received the response")
+end
+
+function scenario:OnCleanup()
+	print("OnCleanup")
+	self.client:Disconnect()
+	self.server:StopListening()
+end
+
+return scenario

--- a/scenarios.lua
+++ b/scenarios.lua
@@ -1,1 +1,10 @@
--- Placeholder; any scenarios added here will be executed as part of the test suite
+-- Acceptance tests (below) use a more verbose format and should only be used for use case scenarios
+local testSuites = {
+	"Tests/Runtime/API/Networking/networking-scenarios.lua",
+}
+
+for _, filePath in pairs(testSuites) do
+	local testSuite = import(filePath)
+	-- For CI pipelines and scripts, ensure the return code indicates EXIT_FAILURE if at least one assertion has failed
+	assert(testSuite:Run(), "Assertion failure in test suite " .. filePath)
+end

--- a/test.lua
+++ b/test.lua
@@ -6,6 +6,7 @@ local testCases = {
 	"Tests/Runtime/API/FileSystem/C_FileSystem.spec.lua",
 	"Tests/Runtime/API/Testing/Scenario.spec.lua",
 	"Tests/Runtime/API/Testing/TestSuite.spec.lua",
+	"Tests/Runtime/API/Networking/C_Networking.spec.lua",
 	"Tests/Primitives/format.spec.lua",
 	"Tests/Primitives/logging.spec.lua",
 	"Tests/Primitives/printf.spec.lua",


### PR DESCRIPTION
Despite my original intention to hook the TCP primitives into the global event registry, I decided to leave them using local handlers for now. Rationale:

* Triggering global events would include some overhead, particularly for global lookups
* Caching them would be possible to eliminate (most of) this overhead, but add extra complexity
* There's little point in tracking incoming data chunks, connection requests etc globally ... or is there?
* Can always swap to using the event system API later if it makes sense

They still implement the standard ``OnEvent`` interface via ``EventListenerMixin``, but that's about the extent of how it is used currently. Not sure about the overall design yet, but I suppose it's flexible enough to try out in practice.