### PR TITLE
Add a nonstandard table count extension

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -9,6 +9,7 @@ exclude_files = {
 	"**/path.lua", -- Not much hope here; this is ported spaghetti code from NodeJS
 }
 ignore = {
+	"143", -- accessing undefined field of global (likely a nonstandard extension)
 	"212", -- unused argument 'self'; not a problem and commonly used for colon notation
 	"213", -- unused loop variable (kept for readability's sake)
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ lua_add_executable(luvi
   Runtime/LuaEnvironment/extensions/import.lua
   Runtime/LuaEnvironment/extensions/mixin.lua
   Runtime/LuaEnvironment/extensions/path.lua
+  Runtime/LuaEnvironment/extensions/tablex.lua
   Runtime/LuaEnvironment/extensions/transform.lua
   Runtime/LuaEnvironment/namespaces.lua
   Runtime/API/FileSystem/C_FileSystem.lua

--- a/Runtime/LuaEnvironment/extensions.lua
+++ b/Runtime/LuaEnvironment/extensions.lua
@@ -22,6 +22,9 @@ local extensionLoaders = {
 	assertions = function()
 		return require("assertions")
 	end,
+	tablex = function()
+		return require("tablex")
+	end,
 }
 
 return extensionLoaders

--- a/Runtime/LuaEnvironment/extensions/tablex.lua
+++ b/Runtime/LuaEnvironment/extensions/tablex.lua
@@ -1,0 +1,13 @@
+local pairs = pairs
+local type = type
+
+function _G.table.count(object)
+	local count = 0
+	for k, v in pairs(object) do
+		-- cdata can trip up nil checks, so it's best to be explicit here
+		if type(v) ~= "nil" then
+			count = count + 1
+		end
+	end
+	return count
+end

--- a/Tests/Extensions/table.spec.lua
+++ b/Tests/Extensions/table.spec.lua
@@ -1,0 +1,31 @@
+describe("table", function()
+	describe("count", function()
+		it("should return zero for empty tables", function()
+			assertEquals(table.count({}), 0)
+		end)
+
+		it("should return the number of array elements if the hash part is empty", function()
+			assertEquals(table.count({ "Hello", "world", 42, 12345 }), 4)
+		end)
+
+		it("should return the number of hash map entries if the array part is empty", function()
+			assertEquals(table.count({ Hello = 42, world = 123 }), 2)
+		end)
+
+		it("should return the total sum of hash map and array entries if neither part is empty", function()
+			assertEquals(table.count({ "Hello world", Hello = 42 }), 2)
+		end)
+
+		it("should skip nils in the array part if the hash map part is empty", function()
+			assertEquals(table.count({ 1, nil, 2, nil, 3 }), 3)
+		end)
+
+		it("should skip nils in the hash map part if the array part is empty", function()
+			assertEquals(table.count({ hi = 42, nil, test = 43, nil, meep = 44 }), 3)
+		end)
+
+		it("should skip nils in tables that have both an array and a hash map part", function()
+			assertEquals(table.count({ hi = 42, nil, 43, nil, meep = 44 }), 3)
+		end)
+	end)
+end)

--- a/test.lua
+++ b/test.lua
@@ -9,6 +9,7 @@ local testCases = {
 	"Tests/Extensions/assertFunctionCalls.spec.lua",
 	"Tests/Extensions/assertThrows.spec.lua",
 	"Tests/Extensions/mixin.spec.lua",
+	"Tests/Extensions/table.spec.lua",
 	"Tests/Extensions/transform.spec.lua",
 }
 


### PR DESCRIPTION
Trivial to implement, but moderately useful in cases where the length operator is insufficient.