### PR TITLE
Add diff computation utilities to the string and table libraries

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -35,6 +35,7 @@ globals = {
 	"ZipFileSystemMixin",
 
 	-- Nonstandard primitives
+	"dump",
 	"format",
 	"printf",
 	"EVENT",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ lua_add_executable(luvi
   Runtime/LuaEnvironment/extensions/import.lua
   Runtime/LuaEnvironment/extensions/mixin.lua
   Runtime/LuaEnvironment/extensions/path.lua
+  Runtime/LuaEnvironment/extensions/stringx.lua
   Runtime/LuaEnvironment/extensions/tablex.lua
   Runtime/LuaEnvironment/extensions/transform.lua
   Runtime/LuaEnvironment/namespaces.lua

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,12 +169,12 @@ lua_add_executable(luvi
   Runtime/LuaEnvironment/ZipFileSystemMixin.lua
   Runtime/LuaEnvironment/primitives.lua
   Runtime/LuaEnvironment/primitives/aliases.lua
+  Runtime/LuaEnvironment/primitives/dump.lua
   Runtime/LuaEnvironment/primitives/v8_string.lua
   Runtime/LuaEnvironment/primitives/logging.lua
   Runtime/LuaEnvironment/primitives/virtual_file_system.lua
   Runtime/LuaEnvironment/extensions.lua
   Runtime/LuaEnvironment/extensions/assertions.lua
-  Runtime/LuaEnvironment/extensions/dump.lua
   Runtime/LuaEnvironment/extensions/import.lua
   Runtime/LuaEnvironment/extensions/mixin.lua
   Runtime/LuaEnvironment/extensions/path.lua

--- a/Runtime/LuaEnvironment/extensions.lua
+++ b/Runtime/LuaEnvironment/extensions.lua
@@ -19,6 +19,9 @@ local extensionLoaders = {
 	assertions = function()
 		return require("assertions")
 	end,
+	stringx = function()
+		return require("stringx")
+	end,
 	tablex = function()
 		return require("tablex")
 	end,

--- a/Runtime/LuaEnvironment/extensions.lua
+++ b/Runtime/LuaEnvironment/extensions.lua
@@ -3,9 +3,6 @@ package.path = package.path .. ";extensions/?.lua;"
 
 -- Since they may depend on primitives that aren't yet preloaded, defer the loading process
 local extensionLoaders = {
-	dump = function()
-		return require("dump")
-	end,
 	-- Nonstandard libraries
 	path = function()
 		return require("path")

--- a/Runtime/LuaEnvironment/extensions/dump.lua
+++ b/Runtime/LuaEnvironment/extensions/dump.lua
@@ -401,13 +401,17 @@ local MAX_TABLE_NESTING_LEVEL = 30
 -- Note: This method is not appropriate for saving/restoring tables.
 -- It is meant to be used by the programmer mainly while debugging a program. (from the original README)
 local print = print
-local options = {
+local DEFAULT_OPTIONS = {
 	depth = MAX_TABLE_NESTING_LEVEL,
 	indent = "\t",
+	silent = false,
 }
 
-return function(...)
-	local dumpValue = inspect(..., options)
-	print(dumpValue)
+return function(object, options)
+	options = options or DEFAULT_OPTIONS
+	local dumpValue = inspect(object, options)
+	if not options.silent then
+		print(dumpValue)
+	end
 	return dumpValue
 end

--- a/Runtime/LuaEnvironment/extensions/stringx.lua
+++ b/Runtime/LuaEnvironment/extensions/stringx.lua
@@ -1,0 +1,29 @@
+local string_sub = string.sub
+local math_max = math.max
+
+function _G.string.diff(before, after)
+	local maxIndexToCheck = math_max(#before, #after)
+	local lastNewlineIndex
+	local numCharsSinceLastNewline = 0
+
+	for index = 1, maxIndexToCheck, 1 do
+		local charAt = string_sub(before, index, index)
+		local charAtDiff = string_sub(after, index, index)
+
+		-- Move index BEFORE the evaluation to ensure it always refers to the first non-matching character
+		if charAt == "\n" then
+			lastNewlineIndex = index
+		end
+
+		if not charAt or not charAtDiff or (charAt ~= charAtDiff) then
+			return index, lastNewlineIndex, numCharsSinceLastNewline
+		end
+
+		-- Move cursor only AFTER the evaluation so ensure it stops in front of the last matching character
+		if charAt ~= "\n" then
+			numCharsSinceLastNewline = numCharsSinceLastNewline + 1
+		else
+			numCharsSinceLastNewline = 0
+		end
+	end
+end

--- a/Runtime/LuaEnvironment/extensions/tablex.lua
+++ b/Runtime/LuaEnvironment/extensions/tablex.lua
@@ -1,4 +1,8 @@
+local dump = dump
 local pairs = pairs
+local string_diff = string.diff
+local string_rep = string.rep
+local string_sub = string.sub
 local type = type
 
 function _G.table.count(object)
@@ -10,4 +14,42 @@ function _G.table.count(object)
 		end
 	end
 	return count
+end
+
+function _G.table.diff(before, after)
+	if type(before) ~= "table" or type(after) ~= "table" then
+		error("Usage: diff(before : table, after : table)", 0)
+	end
+
+	local diffString = ""
+
+	local beforeString = dump(before, { silent = true })
+	local afterString = dump(after, { silent = true })
+
+	-- Early exit to avoid unnecessary computation
+	if beforeString == afterString then
+		return ""
+	end
+
+	-- Compute surrounding lines from the given index
+	local firstDifferingIndex, _, numCharsSinceLastNewline = string_diff(beforeString, afterString)
+	local startString = string_sub(beforeString, 1, firstDifferingIndex)
+	local endString = string_sub(beforeString, firstDifferingIndex + 1)
+
+	diffString = diffString .. "--------------------" .. "\n"
+	diffString = diffString .. startString .. ""
+	diffString = diffString .. endString .. "\n"
+
+	diffString = diffString .. "--------------------" .. "\n"
+
+	startString = string_sub(afterString, 1, firstDifferingIndex)
+	endString = string_sub(afterString, firstDifferingIndex + 1)
+	diffString = diffString .. startString .. "\n"
+	diffString = diffString
+		.. string_rep(" ", numCharsSinceLastNewline)
+		.. transform.brightRed("^ THERE BE A MISMATCH HERE") -- Can't upvalue other extensions (load order)
+	diffString = diffString .. endString .. "\n"
+	diffString = diffString .. "--------------------"
+
+	return diffString
 end

--- a/Runtime/LuaEnvironment/primitives.lua
+++ b/Runtime/LuaEnvironment/primitives.lua
@@ -19,6 +19,9 @@ local primitives = {
 	["aliases"] = function()
 		return require("aliases")
 	end,
+	dump = function()
+		return require("dump")
+	end,
 }
 
 return primitives

--- a/Runtime/LuaEnvironment/primitives/dump.lua
+++ b/Runtime/LuaEnvironment/primitives/dump.lua
@@ -407,7 +407,7 @@ local DEFAULT_OPTIONS = {
 	silent = false,
 }
 
-return function(object, options)
+local function dump(object, options)
 	options = options or DEFAULT_OPTIONS
 	local dumpValue = inspect(object, options)
 	if not options.silent then
@@ -415,3 +415,7 @@ return function(object, options)
 	end
 	return dumpValue
 end
+
+_G.dump = dump
+
+return dump

--- a/Tests/Extensions/string.spec.lua
+++ b/Tests/Extensions/string.spec.lua
@@ -1,0 +1,24 @@
+describe("string", function()
+	describe("diff", function()
+		it("should return nil if both strings are identical", function()
+			assertEquals(string.diff("hello", "hello"), nil)
+		end)
+
+		it("should return the index of the first differing character if both strings are distinct", function()
+			local index, lastNewlineIndex, numCharsSinceLastNewline = string.diff("Hello world", "Hello world!")
+			assertEquals(index, 12)
+			assertEquals(lastNewlineIndex, nil)
+			assertEquals(numCharsSinceLastNewline, 11)
+		end)
+
+		it(
+			"should return the index of the first differing character if both strings are distinct and contain multiple lines",
+			function()
+				local index, lastNewlineIndex, numCharsSinceLastNewline = string.diff("Hello\nworld!", "Hello\nworld!?")
+				assertEquals(index, 13)
+				assertEquals(lastNewlineIndex, 6)
+				assertEquals(numCharsSinceLastNewline, 6)
+			end
+		)
+	end)
+end)

--- a/Tests/Extensions/table.spec.lua
+++ b/Tests/Extensions/table.spec.lua
@@ -28,4 +28,49 @@ describe("table", function()
 			assertEquals(table.count({ hi = 42, nil, 43, nil, meep = 44 }), 3)
 		end)
 	end)
+
+	describe("diff", function()
+		local diff = table.diff
+		it("should raise an error if one of the two parameters is a non-table value", function()
+			local expectedErrorMessage = "Usage: diff(before : table, after : table)"
+			assertThrows(function()
+				diff({}, 42)
+			end, expectedErrorMessage)
+			assertThrows(function()
+				diff(function() end, {})
+			end, expectedErrorMessage)
+			assertThrows(function()
+				diff("asdf", 42)
+			end, expectedErrorMessage)
+		end)
+
+		it("should return an empty string if both tables are empty", function()
+			assertEquals(diff({}, {}), "")
+		end)
+
+		it("should return an empty string if both tables are identical and non-empty", function()
+			assertEquals(diff({ hi = 42, test = { nested = true } }, { hi = 42, test = { nested = true } }), "")
+		end)
+
+		it("should return a positive diff if the second table has a field that the first one is missing", function()
+			local separatorLine = "--------------------"
+			local expectedDiffString = separatorLine
+				.. "\n"
+				.. "{\n  hi = 42,\n  test = {\n    nested = true\n  }\n}"
+				.. "\n"
+				.. separatorLine
+				.. "\n"
+				.. "{\n  hi = 42,\n  test = {\n    nested = true,\n"
+				.. string.rep(" ", 17)
+				.. transform.brightRed("^ THERE BE A MISMATCH HERE")
+				.. "\n    secret = 123\n  }\n}"
+				.. "\n"
+				.. separatorLine
+
+			assertEquals(
+				diff({ hi = 42, test = { nested = true } }, { hi = 42, test = { nested = true, secret = 123 } }),
+				expectedDiffString
+			)
+		end)
+	end)
 end)

--- a/test.lua
+++ b/test.lua
@@ -9,6 +9,7 @@ local testCases = {
 	"Tests/Extensions/assertFunctionCalls.spec.lua",
 	"Tests/Extensions/assertThrows.spec.lua",
 	"Tests/Extensions/mixin.spec.lua",
+	"Tests/Extensions/string.spec.lua",
 	"Tests/Extensions/table.spec.lua",
 	"Tests/Extensions/transform.spec.lua",
 }

--- a/test/extensions/test-dump.lua
+++ b/test/extensions/test-dump.lua
@@ -1,4 +1,4 @@
-local path = _G.dump
+local dump = _G.dump
 _G.currentNamespace = "dump"
 
 -- I would hope all this (and more) is already covered by inspect.lua, but it's better to be safe


### PR DESCRIPTION
Yet another experiment, with the goal of getting proper assertion failures for table comparisons. Whether it's useful enough to keep around, only time will tell.