### PR TITLE
Fix a test failure caused by invalid upvalues

### DIFF
--- a/Runtime/LuaEnvironment/extensions/tablex.lua
+++ b/Runtime/LuaEnvironment/extensions/tablex.lua
@@ -1,6 +1,5 @@
 local dump = dump
 local pairs = pairs
-local string_diff = string.diff
 local string_rep = string.rep
 local string_sub = string.sub
 local type = type
@@ -32,7 +31,8 @@ function _G.table.diff(before, after)
 	end
 
 	-- Compute surrounding lines from the given index
-	local firstDifferingIndex, _, numCharsSinceLastNewline = string_diff(beforeString, afterString)
+	-- Note: Can't upvalue other extensions (load order)
+	local firstDifferingIndex, _, numCharsSinceLastNewline = string.diff(beforeString, afterString)
 	local startString = string_sub(beforeString, 1, firstDifferingIndex)
 	local endString = string_sub(beforeString, firstDifferingIndex + 1)
 
@@ -47,7 +47,7 @@ function _G.table.diff(before, after)
 	diffString = diffString .. startString .. "\n"
 	diffString = diffString
 		.. string_rep(" ", numCharsSinceLastNewline)
-		.. transform.brightRed("^ THERE BE A MISMATCH HERE") -- Can't upvalue other extensions (load order)
+		.. transform.brightRed("^ THERE BE A MISMATCH HERE")
 	diffString = diffString .. endString .. "\n"
 	diffString = diffString .. "--------------------"
 


### PR DESCRIPTION
The string extension isn't necessarily loaded before the table extension, which results in a flaky test.