### PR TITLE
Add coroutine wrapping for the main thread

### DIFF
--- a/Runtime/LuaEnvironment/init.lua
+++ b/Runtime/LuaEnvironment/init.lua
@@ -79,6 +79,13 @@ function Luvi:IsZipApp()
 	return zip ~= nil
 end
 
-return function(args)
-	return Luvi:LuaMain(args)
+local function StartMainThread(args)
+	local mainThread = coroutine.wrap(function()
+		return Luvi:LuaMain(args)
+	end)
+	local exitCode = mainThread()
+	uv.run()
+	return exitCode
 end
+
+return StartMainThread

--- a/Tests/Runtime/LuviAppBundle.spec.lua
+++ b/Tests/Runtime/LuviAppBundle.spec.lua
@@ -34,5 +34,13 @@ describe("LuviAppBundle", function()
 			local expectedErrorMessage = "main.lua:1: whoops" -- Default Lua format (not great, but alas...)
 			assertThrows(codeUnderTest, expectedErrorMessage)
 		end)
+
+		it("should run the main thread in a coroutine", function()
+			local currentThread, isMainThread = coroutine.running()
+			assertEquals(coroutine.status(currentThread), "running")
+			assertEquals(type(currentThread), "thread")
+			-- If running on the main thread, we can't yield to pause until I/O is ready
+			assertFalse(isMainThread)
+		end)
 	end)
 end)


### PR DESCRIPTION
This allows yielding directly from the bundled app, for example to wait for libuv callbacks.