### PR TITLE
Set up scenario-based acceptance testing with a simple framework

### DIFF
--- a/.github/workflows/ci-unix-osx.yml
+++ b/.github/workflows/ci-unix-osx.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Run unit tests
       run: ./evo-luvi test.lua
 
+    - name: Run acceptance tests
+      run: ./evo-luvi scenarios.lua
+
   deploy-linux:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build]

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Run unit tests
         run: ./evo-luvi test.lua
 
+      - name: Run acceptance tests
+        run: ./evo-luvi scenarios.lua
+
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions
         if: startsWith(github.ref, 'refs/tags/v')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,8 @@ lua_add_executable(luvi
   Runtime/API/EventSystem/EventListenerMixin.lua
   Runtime/API/EventSystem/C_EventSystem.lua
   Runtime/API/FileSystem/C_FileSystem.lua
+  Runtime/API/Testing/Scenario.lua
+  Runtime/API/Testing/TestSuite.lua
   Runtime/API/Testing/C_Testing.lua
   ${lpeg_re_lua}
 )

--- a/Runtime/API/Testing/C_Testing.lua
+++ b/Runtime/API/Testing/C_Testing.lua
@@ -1,4 +1,7 @@
-local C_Testing = {}
+local C_Testing = {
+	TestSuite = require("TestSuite"),
+	Scenario = require("Scenario"),
+}
 
 function C_Testing.CreateFauxConsole()
 	local tostring = tostring

--- a/Runtime/API/Testing/Scenario.lua
+++ b/Runtime/API/Testing/Scenario.lua
@@ -1,0 +1,230 @@
+local uv = require("uv")
+
+local format = string.format
+local setmetatable = setmetatable
+local print = print
+
+local time = uv.hrtime
+
+local NOOP_FUNCTION = function() end
+local NANOSECONDS_PER_MILLISECOND = 10E6
+
+local Scenario = {}
+
+function Scenario:Construct(name)
+	local instance = {
+		name = name or "",
+		runTimeInMilliseconds = 0,
+		descriptions = {
+			GIVEN = "",
+			WHEN = "",
+			THEN = "",
+		},
+		assertions = {},
+	}
+
+	instance.__index = Scenario
+	setmetatable(instance, instance)
+
+	return instance
+end
+
+Scenario.__call = Scenario.Construct
+setmetatable(Scenario, Scenario)
+
+-- These should be overridden by user scripts
+Scenario.OnSetup = NOOP_FUNCTION
+Scenario.OnRun = NOOP_FUNCTION
+Scenario.OnEvaluate = NOOP_FUNCTION
+Scenario.OnCleanup = NOOP_FUNCTION
+
+function Scenario:GIVEN(description)
+	if type(description) ~= "string" then
+		return
+	end
+
+	self.descriptions.GIVEN = description
+end
+
+function Scenario:WHEN(description)
+	if type(description) ~= "string" then
+		return
+	end
+
+	self.descriptions.WHEN = description
+end
+
+function Scenario:THEN(description)
+	if type(description) ~= "string" then
+		return
+	end
+
+	self.descriptions.THEN = description
+end
+
+function Scenario:Run(console)
+	local startTimeInNanoseconds = time()
+
+	self:OnSetup()
+	self:OnRun()
+
+	local globalAssert = assert
+
+	local silentAssert = function(condition, description)
+		local isConditionTrue = condition
+
+		description = description or "(no description)"
+
+		local assertionDetails = {
+			description = description,
+			isSuccess = isConditionTrue,
+		}
+		self.assertions[#self.assertions + 1] = assertionDetails
+	end
+
+	_G.assert = silentAssert
+	self:OnEvaluate()
+	_G.assert = globalAssert
+
+	local endTimeInNanoseconds = time()
+	local runTimeInNanoseconds = (endTimeInNanoseconds - startTimeInNanoseconds)
+	local runTimeInMilliseconds = runTimeInNanoseconds / NANOSECONDS_PER_MILLISECOND
+	self.runTimeInMilliseconds = runTimeInMilliseconds
+
+	self:OnCleanup()
+
+	self:OnReport(console)
+end
+
+function Scenario:ToString()
+	local hasResults = self:GetResultsText() ~= ""
+
+	return self:GetOverviewText()
+		.. "\n"
+		-- Displaying the number of assertions is pointless if there are none, but if any are present the summary needs more space
+		.. self:GetResultsText()
+		.. (hasResults and "\n" or "")
+		.. self:GetSummaryText()
+end
+
+function Scenario:GetOverviewText()
+	local displayText = ""
+
+	local LINEBREAK = "\n"
+	local INDENT = "\t"
+
+	displayText = displayText .. LINEBREAK
+	displayText = displayText .. INDENT .. transform.cyan("Scenario: ") .. transform.white(self.name) .. LINEBREAK
+	displayText = displayText .. LINEBREAK
+
+	local preconditionsText = (self.descriptions.GIVEN == "") and "(no preconditions)" or self.descriptions.GIVEN
+	if self.OnSetup == NOOP_FUNCTION then
+		preconditionsText = "(no preconditions)"
+	end
+
+	local scriptText = (self.descriptions.WHEN == "") and "(no code to execute)" or self.descriptions.WHEN
+	if self.OnRun == NOOP_FUNCTION then
+		scriptText = "(no code to execute)"
+	end
+
+	local postconditionsText = (self.descriptions.THEN == "") and "(no postconditions)" or self.descriptions.THEN
+	if self.OnEvaluate == NOOP_FUNCTION then
+		postconditionsText = "(no postconditions)"
+	end
+
+	displayText = displayText
+		.. INDENT
+		.. transform.cyan("GIVEN")
+		.. INDENT
+		.. transform.white(preconditionsText)
+		.. LINEBREAK
+	displayText = displayText .. INDENT .. transform.cyan("WHEN") .. INDENT .. transform.white(scriptText) .. LINEBREAK
+	displayText = displayText
+		.. INDENT
+		.. transform.cyan("THEN")
+		.. INDENT
+		.. transform.white(postconditionsText)
+		.. LINEBREAK
+
+	return displayText
+end
+
+function Scenario:GetResultsText()
+	local coloredResultsText = ""
+	local failedAssertionCount = 0
+
+	for assertionID, assertionDetails in ipairs(self.assertions) do
+		local description = assertionDetails.description
+		local isSuccess = assertionDetails.isSuccess
+
+		local successIcon = transform.yellow("﹖")
+
+		-- Explicitly checking here to avoid nil being interpreted as false
+		if isSuccess == true then
+			successIcon = transform.green("✓")
+		end
+		if isSuccess == false then
+			successIcon = transform.red("✗")
+			failedAssertionCount = failedAssertionCount + 1
+		end
+
+		coloredResultsText = coloredResultsText .. (format("\t\t%s %s", successIcon, description)) .. "\n"
+	end
+
+	return coloredResultsText
+end
+
+function Scenario:GetSummaryText()
+	local totalAssertionCount = #self.assertions
+	local failedAssertionCount = self:GetNumFailedAssertions()
+
+	local coloredSummaryText
+	if failedAssertionCount == 0 then
+		coloredSummaryText =
+			format("%s passing (%.2f ms)", totalAssertionCount - failedAssertionCount, self.runTimeInMilliseconds)
+	end
+
+	if failedAssertionCount > 0 then
+		coloredSummaryText = transform.brightRedBackground(format("%s FAILED assertions", failedAssertionCount))
+	end
+
+	if failedAssertionCount == 1 then -- OCD
+		coloredSummaryText = transform.brightRedBackground("1 FAILED assertion")
+	end
+
+	if totalAssertionCount == 0 then
+		coloredSummaryText = transform.yellow("Warning: Nothing to assert (technically passing...)")
+	end
+
+	return coloredSummaryText
+end
+
+function Scenario:OnReport(console)
+	local printFunction = console and console.print or print
+	printFunction(self:ToString())
+end
+
+function Scenario:GetName()
+	return self.name or ""
+end
+
+function Scenario:GetNumFailedAssertions()
+	local failedAssertionCount = 0
+
+	for assertionID, assertionDetails in ipairs(self.assertions) do
+		local isSuccess = assertionDetails.isSuccess
+
+		-- Explicitly checking here to avoid nil being interpreted as false
+		if isSuccess == false then
+			failedAssertionCount = failedAssertionCount + 1
+		end
+	end
+
+	return failedAssertionCount
+end
+
+function Scenario:HasFailed()
+	return self:GetNumFailedAssertions() > 0
+end
+
+return Scenario

--- a/Runtime/API/Testing/TestSuite.lua
+++ b/Runtime/API/Testing/TestSuite.lua
@@ -1,0 +1,110 @@
+local TestSuite = {
+	-- 80 chars to fit greybeard terminals
+	HORIZONTAL_LINE_SEPARATOR = "--------------------------------------------------------------------------------",
+}
+
+local setmetatable = setmetatable
+local format = string.format
+
+function TestSuite:Construct(name)
+	local instance = {
+		name = name or "",
+		scenarios = {},
+	}
+
+	instance.__index = TestSuite
+	setmetatable(instance, instance)
+
+	return instance
+end
+
+TestSuite.__call = TestSuite.Construct
+setmetatable(TestSuite, TestSuite)
+
+function TestSuite:GetNumScenarios()
+	return #self.scenarios
+end
+
+function TestSuite:Run(console)
+	self:RunAllScenarios(console)
+
+	-- This allows using assert(testSuite:Run(), "Error messag here") to set EXIT_FAILURE for CI pipelines and scripts
+	return not self:HasFailedScenarios()
+end
+
+function TestSuite:HasFailedScenarios()
+	local hasFailedScenarios = false
+	for scenarioID, scenario in ipairs(self.scenarios) do
+		if scenario:HasFailed() then
+			hasFailedScenarios = true
+		end
+	end
+	return hasFailedScenarios
+end
+
+function TestSuite:AddScenario(scenario)
+	self.scenarios[#self.scenarios + 1] = scenario
+end
+
+function TestSuite:AddScenarios(listOfScenarios)
+	for _, scenarioFilePath in pairs(listOfScenarios) do
+		local scenario = import(scenarioFilePath)
+		self:AddScenario(scenario)
+	end
+end
+
+function TestSuite:RunAllScenarios(console)
+	for scenarioID, scenario in ipairs(self.scenarios) do
+		self:RunScenario(scenario)
+	end
+
+	self:ReportSummary(console)
+end
+
+function TestSuite:RunScenario(scenario)
+	if not scenario then
+		return
+	end
+
+	scenario:Run()
+end
+
+function TestSuite:ReportSummary(console)
+	local printMethod = console and console.print or print
+	printMethod(self.HORIZONTAL_LINE_SEPARATOR)
+	printMethod()
+	printMethod(transform.cyan("Test Suite: ") .. transform.white(self.name))
+	printMethod()
+
+	local numFailedScenarios = 0
+
+	-- If no scenarios have been added, this is a NOOP and can be ignored
+	for scenarioID, scenario in ipairs(self.scenarios) do
+		local successIcon = transform.green("✓")
+		if scenario:HasFailed() then
+			successIcon = transform.red("✗")
+			numFailedScenarios = numFailedScenarios + 1
+		end
+
+		local resultsText = scenario:GetSummaryText()
+
+		local summaryText = format("\t%s %s: %s", successIcon, scenario:GetName(), resultsText)
+		printMethod(summaryText)
+	end
+
+	if #self.scenarios > 0 then
+		printMethod()
+	end -- Extra newline increases readability
+
+	if numFailedScenarios == 1 then -- OCD...
+		printMethod(transform.brightRedBackground("1 scenario failed!"))
+	elseif numFailedScenarios > 1 then
+		printMethod(transform.brightRedBackground(format("%s scenarios failed!", numFailedScenarios)))
+	elseif #self.scenarios == 0 then
+		printMethod(transform.yellow("Warning: No scenarios to run (technically passing...)"))
+	else
+		printMethod(transform.green("All scenarios completed successfully!"))
+	end
+end
+
+return TestSuite

--- a/Runtime/LuaEnvironment/extensions/transform.lua
+++ b/Runtime/LuaEnvironment/extensions/transform.lua
@@ -32,7 +32,7 @@ end
 
 local function transformText(text, color)
 	if type(text) ~= "string" then
-		ERROR("Usage: transform." .. color .. "(text : string)")
+		error("Usage: transform." .. color .. "(text : string)", 0)
 	end
 
 	if not transform.ENABLE_TEXT_TRANSFORMATIONS then

--- a/Runtime/LuaEnvironment/primitives/logging.lua
+++ b/Runtime/LuaEnvironment/primitives/logging.lua
@@ -20,7 +20,7 @@ function logging.warning(message, ...)
 	print("[WARNING]", message, ...)
 end
 function logging.error(message, showTraceback)
-	error(message .. (showTraceback and debug.traceback("", 2) or ""), 0)
+	print("[ERROR]", message .. (showTraceback and debug.traceback("", 2) or ""), 0)
 end
 function logging.critical(message, ...)
 	print("[CRITICAL]", message, ...)

--- a/Tests/Fixtures/example-scenario-file-1.lua
+++ b/Tests/Fixtures/example-scenario-file-1.lua
@@ -1,0 +1,7 @@
+local scenario = C_Testing.Scenario("Asserting some stuff")
+
+function scenario:OnEvaluate()
+	assert(1 == 1, "Some description")
+end
+
+return scenario

--- a/Tests/Fixtures/example-scenario-file-2.lua
+++ b/Tests/Fixtures/example-scenario-file-2.lua
@@ -1,0 +1,7 @@
+local scenario = C_Testing.Scenario("Asserting some more stuff")
+
+function scenario:OnEvaluate()
+	assert(1 == 1, "Some description")
+end
+
+return scenario

--- a/Tests/Runtime/API/Testing/Scenario.spec.lua
+++ b/Tests/Runtime/API/Testing/Scenario.spec.lua
@@ -1,0 +1,308 @@
+describe("Scenario", function()
+	local function createNoOpScenario()
+		return C_Testing.Scenario("Do nothing")
+	end
+
+	local function createMultiAssertionScenario()
+		local scenario = C_Testing.Scenario("Multiple assertions (some failing)")
+
+		local someValue = 0
+
+		scenario:GIVEN("Some preconditions are true")
+		scenario:WHEN("I run the test code")
+		scenario:THEN("The post-conditions hold true")
+
+		function scenario:OnRun()
+			someValue = 42
+		end
+
+		function scenario:OnEvaluate()
+			-- Mixing standard and nonstandard assertions here, with and without descriptions, to ensure all combinations work
+			assert(someValue == 42)
+			assert(someValue == 42, "Some value is set to 42")
+			assertEquals(someValue, 43)
+			assertEquals(someValue, 43, "Some value is set to 43")
+			assert(someValue == 44, "Some value is set to 44")
+		end
+
+		return scenario
+	end
+
+	local function getNoOpScenarioOverviewText()
+		-- Human-readable overview should indicate no handlers were registered
+		local expectedOverviewText = "\n" -- To offset from the previous content (sub-optimal...)
+
+		expectedOverviewText = expectedOverviewText .. "\t" -- To highlight the keywords visually
+		expectedOverviewText = expectedOverviewText
+			.. transform.cyan("Scenario: ")
+			.. transform.white("Do nothing")
+			.. "\n\n"
+		expectedOverviewText = expectedOverviewText
+			.. "\t"
+			.. transform.cyan("GIVEN")
+			.. "\t"
+			.. transform.white("(no preconditions)")
+			.. "\n"
+		expectedOverviewText = expectedOverviewText
+			.. "\t"
+			.. transform.cyan("WHEN")
+			.. "\t"
+			.. transform.white("(no code to execute)")
+			.. "\n"
+		expectedOverviewText = expectedOverviewText
+			.. "\t"
+			.. transform.cyan("THEN")
+			.. "\t"
+			.. transform.white("(no postconditions)")
+			.. "\n"
+		return expectedOverviewText
+	end
+
+	local function getMultiAssertionsScenarioOverviewText()
+		local expectedOverviewText = "\n" -- To offset from the previous content (sub-optimal...)
+		expectedOverviewText = expectedOverviewText .. "\t" -- To highlight the keywords visually
+		expectedOverviewText = expectedOverviewText
+			.. transform.cyan("Scenario: ")
+			.. transform.white("Multiple assertions (some failing)")
+			.. "\n\n"
+		expectedOverviewText = expectedOverviewText
+			.. "\t"
+			.. transform.cyan("GIVEN")
+			.. "\t"
+			.. transform.white("(no preconditions)")
+			.. "\n"
+		expectedOverviewText = expectedOverviewText
+			.. "\t"
+			.. transform.cyan("WHEN")
+			.. "\t"
+			.. transform.white("I run the test code")
+			.. "\n"
+		expectedOverviewText = expectedOverviewText
+			.. "\t"
+			.. transform.cyan("THEN")
+			.. "\t"
+			.. transform.white("The post-conditions hold true")
+			.. "\n"
+		return expectedOverviewText
+	end
+
+	local function getMultiAssertionsScenarioResultsText()
+		local green = transform.green
+		local red = transform.red
+		local bold = transform.bold
+
+		local expectedResultsText = "\t\t" .. green("✓") .. " (no description)\n"
+		expectedResultsText = expectedResultsText .. "\t\t" .. green("✓") .. " Some value is set to 42\n"
+		expectedResultsText = expectedResultsText
+			.. "\t\t"
+			.. red("✗")
+			.. " "
+			.. bold("42")
+			.. " is not "
+			.. bold("43")
+			.. "\n"
+		expectedResultsText = expectedResultsText .. "\t\t" .. red("✗") .. " Some value is set to 43\n"
+		expectedResultsText = expectedResultsText .. "\t\t" .. red("✗") .. " Some value is set to 44\n"
+		return expectedResultsText
+	end
+
+	describe("Construct", function()
+		it("should initialize a new scenario with the given name", function()
+			local scenario = createNoOpScenario()
+			assertEquals(scenario:GetName(), "Do nothing")
+		end)
+	end)
+
+	describe("Run", function()
+		it("should display the full report text when a scenario without assertions is run", function()
+			local scenario = createNoOpScenario()
+			local expectedOverviewText = getNoOpScenarioOverviewText()
+			local fauxConsole = C_Testing.CreateFauxConsole()
+			assertEquals(fauxConsole.read(), "", "Should not have printed anything before the scenario was run")
+
+			local expectedResultsText = ""
+			scenario:Run(fauxConsole)
+			local expectedSummaryText = transform.yellow("Warning: Nothing to assert (technically passing...)")
+			local expectedOutput = expectedOverviewText .. expectedResultsText .. "\n" .. expectedSummaryText .. "\n"
+			assertEquals(fauxConsole.read(), expectedOutput)
+		end)
+
+		it("should call the default event handlers when a scenario is run", function()
+			local scenario = C_Testing.Scenario("Event handlers are called when a scenario is run")
+
+			local numSetupExecutions = 0
+			local numTestExecutions = 0
+			local numEvaluationExecutions = 0
+			local numCleanupExecutions = 0
+
+			scenario.someValue = 42
+
+			function scenario:OnSetup()
+				numSetupExecutions = numSetupExecutions + 1
+				assertEquals(self.someValue, 42, "Parameter self should be passed to OnSetup")
+			end
+
+			function scenario:OnRun()
+				numTestExecutions = numTestExecutions + 1
+				assertEquals(self.someValue, 42, "Parameter self should be passed to OnRun")
+			end
+
+			function scenario:OnEvaluate()
+				numEvaluationExecutions = numEvaluationExecutions + 1
+				assertEquals(self.someValue, 42, "Parameter self should be passed to OnEvaluate")
+			end
+
+			function scenario:OnCleanup()
+				numCleanupExecutions = numCleanupExecutions + 1
+				assertEquals(self.someValue, 42, "Parameter self should be passed to OnCleanup")
+			end
+
+			assertEquals(numSetupExecutions, 0, "Should not call the OnSetup handler before the scenario was run")
+			assertEquals(numTestExecutions, 0, "Should not call the OnRun handler before the scenario was run")
+			assertEquals(
+				numEvaluationExecutions,
+				0,
+				"Should not call the OnEvaluate handler before the scenario was run"
+			)
+			assertEquals(numCleanupExecutions, 0, "Should not call the OnCleanup handler before the scenario was run")
+
+			scenario:Run()
+
+			assertEquals(numSetupExecutions, 1, "Should call the OnSetup handler when the scenario is run")
+			assertEquals(numTestExecutions, 1, "Should call the OnRun handler when the scenario is run")
+			assertEquals(numEvaluationExecutions, 1, "Should call the OnEvaluate handler when the scenario is run")
+			assertEquals(numCleanupExecutions, 1, "Should call the OnCleanup handler when the scenario is run")
+
+			scenario:Run()
+
+			assertEquals(numSetupExecutions, 2, "Should call the OnSetup handler again when the scenario is run twice")
+			assertEquals(numTestExecutions, 2, "Should call the OnRun handler again when the scenario is run twice")
+			assertEquals(
+				numEvaluationExecutions,
+				2,
+				"Should call the OnEvaluate handler again when the scenario is run twice"
+			)
+			assertEquals(
+				numCleanupExecutions,
+				2,
+				"Should call the OnCleanup handler again when the scenario is run twice"
+			)
+		end)
+
+		it(
+			"should display the full report text when a scenario with both passing and failing assertions is run",
+			function()
+				local scenario = createMultiAssertionScenario()
+				local expectedResultsText = getMultiAssertionsScenarioResultsText()
+
+				local fauxConsole = C_Testing.CreateFauxConsole()
+				assertEquals(fauxConsole.read(), "", "Should not have printed anything before the scenario was run")
+
+				scenario:Run(fauxConsole)
+
+				local expectedOverviewText = getMultiAssertionsScenarioOverviewText()
+				local expectedSummaryText = transform.brightRedBackground("3 FAILED assertions")
+				local expectedOutput = expectedOverviewText
+					.. "\n"
+					.. expectedResultsText
+					.. "\n"
+					.. expectedSummaryText
+					.. "\n"
+				assertEquals(fauxConsole.read(), expectedOutput)
+				fauxConsole.clear()
+			end
+		)
+	end)
+
+	describe("HasFailed", function()
+		it("should return false if no assertions have been added", function()
+			local scenario = createNoOpScenario()
+			assertFalse(scenario:HasFailed())
+		end)
+
+		it("should return false if assertions have been added, but the scenario hasn't yet run", function()
+			local scenario = createMultiAssertionScenario()
+			assertFalse(scenario:HasFailed())
+		end)
+
+		it("should return true if some assertions have failed after the scenario was run", function()
+			local scenario = createMultiAssertionScenario()
+			scenario:Run()
+			assertTrue(scenario:HasFailed())
+		end)
+	end)
+
+	describe("GetNumFailedAssertions", function()
+		it("should return zero if no assertions have been added", function()
+			local scenario = createNoOpScenario()
+			assertEquals(scenario:GetNumFailedAssertions(), 0)
+		end)
+
+		it("should return zero if assertions have been added, but the scenario hasn't yet run", function()
+			local scenario = createMultiAssertionScenario()
+			assertEquals(scenario:GetNumFailedAssertions(), 0)
+		end)
+
+		it("should return the number of failed assertions if a scenario has been run", function()
+			local scenario = createMultiAssertionScenario()
+			scenario:Run()
+			assertEquals(
+				scenario:GetNumFailedAssertions(),
+				3,
+				"Should return the number of failed assertions after the scenario was run"
+			)
+		end)
+	end)
+
+	describe("GetOverviewText", function()
+		it("should return a string representation of the scenario in a standardized format", function()
+			local scenario = createNoOpScenario()
+			local expectedOverviewText = getNoOpScenarioOverviewText()
+			assertEquals(scenario:GetOverviewText(), expectedOverviewText)
+
+			expectedOverviewText = getMultiAssertionsScenarioOverviewText()
+			scenario = createMultiAssertionScenario()
+			assertEquals(
+				scenario:GetOverviewText(),
+				expectedOverviewText,
+				"Should return a string representation of the scenario in a standardized format"
+			)
+		end)
+	end)
+
+	describe("GetResultsText", function()
+		it("should return an empty string if no assertions have been added", function()
+			local scenario = createNoOpScenario()
+			local expectedResultsText = ""
+			assertEquals(scenario:GetResultsText(), expectedResultsText)
+		end)
+
+		it(
+			"should return the evaluation results if a scenario with both failing and passing assertions was run",
+			function()
+				local expectedResultsText = getMultiAssertionsScenarioResultsText()
+				local scenario = createMultiAssertionScenario()
+				scenario:Run()
+				assertEquals(scenario:GetResultsText(), expectedResultsText)
+			end
+		)
+	end)
+
+	describe("GetSummaryText", function()
+		it("should return a warning instead of the summary if no assertions have been added", function()
+			local scenario = createNoOpScenario()
+			local expectedSummaryText = transform.yellow("Warning: Nothing to assert (technically passing...)")
+			assertEquals(scenario:GetSummaryText(), expectedSummaryText)
+		end)
+
+		it(
+			"should return the number of failed assertions if a scenario with failing assertions has been run",
+			function()
+				local scenario = createMultiAssertionScenario()
+				scenario:Run()
+				local expectedSummaryText = transform.brightRedBackground("3 FAILED assertions")
+				assertEquals(scenario:GetSummaryText(), expectedSummaryText)
+			end
+		)
+	end)
+end)

--- a/Tests/Runtime/API/Testing/TestSuite.spec.lua
+++ b/Tests/Runtime/API/Testing/TestSuite.spec.lua
@@ -1,0 +1,204 @@
+describe("TestSuite", function()
+	local emptyTestSuite = C_Testing.TestSuite("TestSuite with no scenarios")
+
+	local function createFailingTestSuite()
+		local failingTestSuiteWithOneScenario = C_Testing.TestSuite("TestSuite with multiple failing assertions")
+		local scenario = C_Testing.Scenario("NOOP scenario")
+
+		function scenario:OnEvaluate()
+			assert(1 == 1, "NOOP assertion #1")
+			assert(42 == 0, "FAILED assertion #1")
+			assert(1234 == 12345, "FAILED assertion #2")
+		end
+
+		failingTestSuiteWithOneScenario:AddScenario(scenario)
+		return failingTestSuiteWithOneScenario
+	end
+
+	local function createPassingTestSuite()
+		local testSuite = C_Testing.TestSuite("TestSuite with multiple passing assertions")
+
+		assertEquals(testSuite:GetNumScenarios(), 0, "Should return zero if no scenarios have been added")
+
+		local scenario = C_Testing.Scenario("NOOP scenario")
+
+		function scenario:OnEvaluate()
+			assert(1 == 1, "NOOP assertion #1")
+			assert(42 == 42, "NOOP assertion #2")
+			assert(1234 == 1234, "NOOP assertion #3")
+		end
+
+		testSuite:AddScenario(scenario)
+
+		return testSuite
+	end
+
+	local function createMultiScenarioTestSuite()
+		local testSuite = C_Testing.TestSuite("Adding multiple scenarios at once")
+
+		local listOfScenarioFilesToLoad = {
+			"../../Fixtures/example-scenario-file-1.lua",
+			"../../Fixtures/example-scenario-file-2.lua",
+		}
+
+		testSuite:AddScenarios(listOfScenarioFilesToLoad)
+
+		return testSuite
+	end
+
+	describe("GetNumScenarios", function()
+		it("should return zero if no scenarios have been added", function()
+			assertEquals(emptyTestSuite:GetNumScenarios(), 0)
+		end)
+
+		it("should return one if a single scenario has been added", function()
+			local failingTestSuiteWithOneScenario = createFailingTestSuite()
+			assertEquals(
+				failingTestSuiteWithOneScenario:GetNumScenarios(),
+				1,
+				"Should return one if a single scenarios has been added"
+			)
+		end)
+	end)
+
+	describe("ReportSummary", function()
+		it(
+			"should display a summary text indicating no scenarios have been added if test suite wasn't yet run",
+			function()
+				local fauxConsole = C_Testing.CreateFauxConsole()
+				emptyTestSuite:ReportSummary(fauxConsole)
+
+				local expectedConsoleOutput = C_Testing.TestSuite.HORIZONTAL_LINE_SEPARATOR .. "\n\n"
+				expectedConsoleOutput = expectedConsoleOutput
+					.. transform.cyan("Test Suite: ")
+					.. transform.white("TestSuite with no scenarios")
+					.. "\n\n"
+				expectedConsoleOutput = expectedConsoleOutput
+					.. transform.yellow("Warning: No scenarios to run (technically passing...)")
+					.. "\n"
+				assertEquals(fauxConsole.read(), expectedConsoleOutput, "")
+			end
+		)
+	end)
+
+	describe("HasFailedScenarios", function()
+		it("should return false if no scenarios have been added", function()
+			assertFalse(emptyTestSuite:HasFailedScenarios())
+		end)
+
+		it("should return true if at least one scenario has failed", function()
+			local failingTestSuiteWithOneScenario = createFailingTestSuite()
+			failingTestSuiteWithOneScenario:Run()
+			assertTrue(failingTestSuiteWithOneScenario:HasFailedScenarios())
+		end)
+
+		it("should return false if no scenarios have failed", function()
+			local testSuite = createPassingTestSuite()
+			assertFalse(testSuite:HasFailedScenarios())
+		end)
+	end)
+
+	describe("Run", function()
+		it("should return false if at least one assertion has failed", function()
+			local testSuite = C_Testing.TestSuite("Failing test runner generates EXIT_FAILURE code")
+
+			local failingScenario = C_Testing.Scenario("Scenario with failed assertion")
+			function failingScenario:OnEvaluate()
+				assert(1 == 0, "Should always fail and raise an error in the process")
+			end
+			testSuite:AddScenario(failingScenario)
+			assertFalse(testSuite:Run())
+		end)
+
+		it("should return true if not a single assertion has failed", function()
+			local testSuite = C_Testing.TestSuite("Passing test runner generates EXIT_SUCCESS code")
+
+			local passingScenario = C_Testing.Scenario("Scenario with passing assertion")
+			function passingScenario:OnEvaluate()
+				assert(1 == 1, "Should always succeed and NOT raise an error in the process")
+			end
+			testSuite:AddScenario(passingScenario)
+			assertTrue(testSuite:Run())
+		end)
+
+		it(
+			"should display a summary text indicating no assertions have failed when a passing test suite is run",
+			function()
+				local testSuite = createPassingTestSuite()
+				local fauxConsole = C_Testing.CreateFauxConsole()
+				assertEquals(fauxConsole.read(), "")
+				testSuite:Run(fauxConsole)
+				local expectedConsoleOutput = C_Testing.TestSuite.HORIZONTAL_LINE_SEPARATOR .. "\n\n"
+				-- The 0.00ms is kinda risky here, but it's probably safe to assume the three NOOPS won't take any significant time...
+				expectedConsoleOutput = expectedConsoleOutput
+					.. transform.cyan("Test Suite: ")
+					.. transform.white("TestSuite with multiple passing assertions")
+					.. "\n\n"
+				expectedConsoleOutput = expectedConsoleOutput
+					.. "\t"
+					.. transform.green("✓")
+					.. " "
+					.. "NOOP scenario: 3 passing (0.00 ms)"
+					.. "\n\n"
+				expectedConsoleOutput = expectedConsoleOutput
+					.. transform.green("All scenarios completed successfully!")
+					.. "\n"
+				assertEquals(fauxConsole.read(), expectedConsoleOutput)
+			end
+		)
+
+		it("should display a summary text indicating the failed assertions when a failing test suite is run", function()
+			local failingTestSuiteWithOneScenario = createFailingTestSuite()
+			local fauxConsole = C_Testing.CreateFauxConsole()
+
+			assertEquals(fauxConsole.read(), "", "Should not display anything before the test suite was run")
+			failingTestSuiteWithOneScenario:Run(fauxConsole)
+
+			local expectedConsoleOutput = C_Testing.TestSuite.HORIZONTAL_LINE_SEPARATOR .. "\n\n"
+			-- The 0.00ms is kinda risky here, but it's probably safe to assume the three NOOPS won't take any significant time...
+			expectedConsoleOutput = expectedConsoleOutput
+				.. transform.cyan("Test Suite: ")
+				.. transform.white("TestSuite with multiple failing assertions")
+				.. "\n\n"
+			expectedConsoleOutput = expectedConsoleOutput
+				.. "\t"
+				.. transform.red("✗")
+				.. " "
+				.. "NOOP scenario: "
+				.. transform.brightRedBackground("2 FAILED assertions")
+				.. "\n\n"
+			expectedConsoleOutput = expectedConsoleOutput .. transform.brightRedBackground("1 scenario failed!") .. "\n"
+			assertEquals(fauxConsole.read(), expectedConsoleOutput)
+		end)
+
+		it("should display the expected result after loading and running multiple passing scenario files", function()
+			local testSuite = createMultiScenarioTestSuite()
+			local fauxConsole = C_Testing.CreateFauxConsole()
+
+			testSuite:Run(fauxConsole)
+
+			local expectedConsoleOutput = C_Testing.TestSuite.HORIZONTAL_LINE_SEPARATOR .. "\n\n"
+			expectedConsoleOutput = expectedConsoleOutput
+				.. transform.cyan("Test Suite: ")
+				.. transform.white("Adding multiple scenarios at once")
+				.. "\n\n"
+			expectedConsoleOutput = expectedConsoleOutput
+				.. "\t"
+				.. transform.green("✓")
+				.. " "
+				.. "Asserting some stuff: 1 passing (0.00 ms)"
+				.. "\n"
+			expectedConsoleOutput = expectedConsoleOutput
+				.. "\t"
+				.. transform.green("✓")
+				.. " "
+				.. "Asserting some more stuff: 1 passing (0.00 ms)"
+				.. "\n\n"
+			expectedConsoleOutput = expectedConsoleOutput
+				.. transform.green("All scenarios completed successfully!")
+				.. "\n"
+
+			assertEquals(fauxConsole.read(), expectedConsoleOutput)
+		end)
+	end)
+end)

--- a/scenarios.lua
+++ b/scenarios.lua
@@ -1,0 +1,1 @@
+-- Placeholder; any scenarios added here will be executed as part of the test suite

--- a/test.lua
+++ b/test.lua
@@ -4,6 +4,8 @@ local testCases = {
 	"Tests/Runtime/API/EventSystem/EventListenerMixin.spec.lua",
 	"Tests/Runtime/API/EventSystem/C_EventSystem.spec.lua",
 	"Tests/Runtime/API/FileSystem/C_FileSystem.spec.lua",
+	"Tests/Runtime/API/Testing/Scenario.spec.lua",
+	"Tests/Runtime/API/Testing/TestSuite.spec.lua",
 	"Tests/Primitives/format.spec.lua",
 	"Tests/Primitives/logging.spec.lua",
 	"Tests/Primitives/printf.spec.lua",


### PR DESCRIPTION
This seems more appropriate for complex, use-case based tests (e.g., creating a server and testing it). It's a bit more involved, so there should still be a reason to use the existing unit test runner.

Note: Had to change the default ERROR handler in order to make scenarios work. Not ideal, but before there's a proper logging framework it doesn't really matter...