### PR TITLE
Add more examples for using CLI arguments

### DIFF
--- a/Runtime/LuaEnvironment/init.lua
+++ b/Runtime/LuaEnvironment/init.lua
@@ -51,6 +51,7 @@ local CLI = require("CLI")
 
 function Luvi:LuaMain(commandLineArgumentsPassedFromC)
 	self.commandLineArguments = commandLineArgumentsPassedFromC
+	_G.arg = commandLineArgumentsPassedFromC -- Mimick the standard arg global to avoid confusing users
 
 	-- When the executable contains a luvi-based app, it should be run instead of the default CLI
 	if self:IsZipApp() then

--- a/Tests/Examples/cli-app-args.lua
+++ b/Tests/Examples/cli-app-args.lua
@@ -1,0 +1,11 @@
+local arguments = { ... }
+
+print("Number of command-line arguments received:", #arguments)
+
+print("Dumping command-line arguments...")
+dump(arguments)
+
+print("Iterating over command-line arguments...")
+for index, argument in pairs(arguments) do
+	print(index, argument)
+end

--- a/Tests/Examples/cli-global-arg.lua
+++ b/Tests/Examples/cli-global-arg.lua
@@ -1,0 +1,11 @@
+local arguments = { ... }
+
+print("Number of command-line arguments received:", #arguments)
+
+print("Dumping command line arguments (only those after the -- delimiter)...")
+dump(arguments)
+
+-- Alternatively, access the full arguments vector (argv in C) passed to the runtime
+print("Dumping command line arguments (the full C arguments vector)...")
+print("Full arguments count:", #arg)
+dump(arg)


### PR DESCRIPTION
Also fixes the missing global ``arg`` export, which is implicitly tested by the second example...