### PR TITLE
Add a SIGPIPE signal handler for TCP Servers

### DIFF
--- a/Runtime/API/Networking/TcpServer.lua
+++ b/Runtime/API/Networking/TcpServer.lua
@@ -42,6 +42,13 @@ function TcpServer:Construct(creationOptions)
 
 	setmetatable(instance, self)
 
+	-- An unhandled SIGPIPE error signal will crash the server on platforms that send it, e.g. when attempting to write to a closed socket
+	if uv.constants.SIGPIPE then
+		local sigpipeSignal = uv.new_signal()
+		sigpipeSignal:start("sigpipe")
+		uv.unref(sigpipeSignal) -- This empty signal handler shouldn't prevent the event loop from exiting as it's a no-op
+	end
+
 	instance:StartListening()
 
 	return instance

--- a/Tests/Runtime/API/Networking/networking-scenarios.lua
+++ b/Tests/Runtime/API/Networking/networking-scenarios.lua
@@ -2,6 +2,7 @@ local testSuite = C_Testing.TestSuite("Networking API")
 
 local listOfScenarioFilesToLoad = {
 	"./tcp-echo.lua",
+	"./tcp-sigpipe.lua",
 }
 
 testSuite:AddScenarios(listOfScenarioFilesToLoad)

--- a/Tests/Runtime/API/Networking/tcp-sigpipe.lua
+++ b/Tests/Runtime/API/Networking/tcp-sigpipe.lua
@@ -1,0 +1,70 @@
+local uv = require("uv")
+
+if not uv.constants.SIGPIPE then
+	-- The constant is set if and only if the signal exists (i.e., Unix-like platforms); others don't need to care about handling it
+	local jit = require("jit")
+	TEST(transform.yellow(format("Skipped test: TCP server receives SIGPIPE (Not relevant to platform %s)", jit.os)))
+	return
+end
+
+local scenario = C_Testing.Scenario("TCP server receives SIGPIPE")
+local TcpServer = C_Networking.TcpServer
+
+scenario:GIVEN("A TCP echo server is listening on localhost")
+scenario:WHEN("It receives a SIGPIPE error signal from an external source")
+scenario:THEN("The server should not crash and continue to operate normally")
+
+local hasSentSignal = false
+
+function scenario:OnSetup()
+	local serverOptions = {
+		port = 9123,
+		hostName = "127.0.0.1",
+	}
+	self.server = TcpServer(serverOptions)
+end
+
+function scenario:OnRun()
+	local currentThread = coroutine.running()
+
+	local server = self.server
+
+	local function setTimeout(timeout, callback)
+		local timer = uv.new_timer()
+		timer:start(timeout, 0, function()
+			timer:stop()
+			timer:close()
+			callback()
+		end)
+		return timer
+	end
+
+	local currentProcessID = uv.os_getpid()
+	local currentParentProcessID = uv.os_getppid()
+	TEST(format("This TCP echo server is running in process %d", currentProcessID))
+	TEST(format("Parent process: %d", currentParentProcessID))
+
+	setTimeout(5, function()
+		TEST("Sending SIGPIPE to current process (pretend it came from the OS...)")
+		os.execute("ps -A")
+		local killCommandString = "kill -" .. uv.constants.SIGPIPE .. " " .. currentProcessID
+		TEST("Executing command: " .. killCommandString)
+		os.execute(killCommandString)
+		hasSentSignal = true
+	end)
+
+	setTimeout(100, function()
+		TEST("No SIGPIPE error signal received yet; shutting down echo server...")
+		server:StopListening()
+		coroutine.resume(currentThread)
+	end)
+
+	-- Hand off control to libuv to let async requests complete
+	coroutine.yield()
+end
+
+function scenario:OnEvaluate()
+	assertTrue(hasSentSignal, "The server should have received the SIGPIPE error signal")
+end
+
+return scenario


### PR DESCRIPTION
While this doesn't affect Windows, on UNIX the OS can send this signal when a socket has gone away and the server's trying to write to it still. If uncaught, this will kill the runtime, taking the server with it... That's basically a self-DOS waiting to happen (and it can appear "randomly", so it would be quite annoying to reproduce in production).

This test doesn't simulate a real-world scenario in order to keep the complexity low. It does verify that receiving a SIGPIPE won't crash the server, which is good enough. It should be safe to rely on the OS sending the signal if (and only if) it's appropriate, anyway.

This CAN be manually reproduced with the following steps:

1. Start TCP echo server in one shell
2. In another shell: nc localhost 12345 < /dev/zero > /dev/null
3. CTRL/C the netcat shell
4. TCP echo server will receive SIGPIPE while writing to the socket

This proved too annoying to reproduce in code, even with spawning child processes I couldn't get it to work. So I opted to just simulate the signal itself and simply call it a day.