### PR TITLE
Fix the displayed time in unit and acceptance test results

### DIFF
--- a/Runtime/API/Testing/C_Testing.lua
+++ b/Runtime/API/Testing/C_Testing.lua
@@ -3,6 +3,8 @@ local C_Testing = {
 	Scenario = require("Scenario"),
 }
 
+local NANOSECONDS_PER_MILLISECOND = 10E5
+
 function C_Testing.CreateFauxConsole()
 	local tostring = tostring
 
@@ -137,7 +139,7 @@ function C_Testing.CreateUnitTestRunner(testCases)
 	end
 
 	local timeEnd = uv.hrtime()
-	local durationInMilliseconds = (timeEnd - timeStart) / 10E6 -- ns (hrtime) to ms
+	local durationInMilliseconds = (timeEnd - timeStart) / NANOSECONDS_PER_MILLISECOND -- ns (hrtime) to ms
 	durationInMilliseconds = math.floor(durationInMilliseconds + 0.5)
 
 	print()

--- a/Runtime/API/Testing/Scenario.lua
+++ b/Runtime/API/Testing/Scenario.lua
@@ -62,6 +62,10 @@ function Scenario:THEN(description)
 	self.descriptions.THEN = description
 end
 
+function Scenario:SetDisplayedTime(runTimeInMilliseconds)
+	self.runTimeInMilliseconds = runTimeInMilliseconds
+end
+
 function Scenario:Run(console)
 	local startTimeInNanoseconds = time()
 
@@ -89,7 +93,7 @@ function Scenario:Run(console)
 	local endTimeInNanoseconds = time()
 	local runTimeInNanoseconds = (endTimeInNanoseconds - startTimeInNanoseconds)
 	local runTimeInMilliseconds = runTimeInNanoseconds / NANOSECONDS_PER_MILLISECOND
-	self.runTimeInMilliseconds = runTimeInMilliseconds
+	self:SetDisplayedTime(runTimeInMilliseconds)
 
 	self:OnCleanup()
 

--- a/Runtime/API/Testing/Scenario.lua
+++ b/Runtime/API/Testing/Scenario.lua
@@ -7,7 +7,7 @@ local print = print
 local time = uv.hrtime
 
 local NOOP_FUNCTION = function() end
-local NANOSECONDS_PER_MILLISECOND = 10E6
+local NANOSECONDS_PER_MILLISECOND = 10E5
 
 local Scenario = {}
 

--- a/Tests/Fixtures/example-scenario-file-1.lua
+++ b/Tests/Fixtures/example-scenario-file-1.lua
@@ -4,4 +4,8 @@ function scenario:OnEvaluate()
 	assert(1 == 1, "Some description")
 end
 
+function scenario:SetDisplayedTime()
+	-- No-op to avoid fluctuations in the actual runtime breaking the tests
+end
+
 return scenario

--- a/Tests/Fixtures/example-scenario-file-2.lua
+++ b/Tests/Fixtures/example-scenario-file-2.lua
@@ -4,4 +4,8 @@ function scenario:OnEvaluate()
 	assert(1 == 1, "Some description")
 end
 
+function scenario:SetDisplayedTime()
+	-- No-op to avoid fluctuations in the actual runtime breaking the tests
+end
+
 return scenario

--- a/Tests/Runtime/API/Testing/Scenario.spec.lua
+++ b/Tests/Runtime/API/Testing/Scenario.spec.lua
@@ -1,6 +1,12 @@
 describe("Scenario", function()
 	local function createNoOpScenario()
-		return C_Testing.Scenario("Do nothing")
+		local scenario = C_Testing.Scenario("Do nothing")
+
+		function scenario:SetDisplayedTime()
+			-- No-op to avoid fluctuations in the actual runtime breaking the tests
+		end
+
+		return scenario
 	end
 
 	local function createMultiAssertionScenario()
@@ -23,6 +29,10 @@ describe("Scenario", function()
 			assertEquals(someValue, 43)
 			assertEquals(someValue, 43, "Some value is set to 43")
 			assert(someValue == 44, "Some value is set to 44")
+		end
+
+		function scenario:SetDisplayedTime()
+			-- No-op to avoid fluctuations in the actual runtime breaking the tests
 		end
 
 		return scenario

--- a/Tests/Runtime/API/Testing/TestSuite.spec.lua
+++ b/Tests/Runtime/API/Testing/TestSuite.spec.lua
@@ -11,6 +11,10 @@ describe("TestSuite", function()
 			assert(1234 == 12345, "FAILED assertion #2")
 		end
 
+		function scenario:SetDisplayedTime()
+			-- No-op to avoid fluctuations in the actual runtime breaking the tests
+		end
+
 		failingTestSuiteWithOneScenario:AddScenario(scenario)
 		return failingTestSuiteWithOneScenario
 	end
@@ -26,6 +30,10 @@ describe("TestSuite", function()
 			assert(1 == 1, "NOOP assertion #1")
 			assert(42 == 42, "NOOP assertion #2")
 			assert(1234 == 1234, "NOOP assertion #3")
+		end
+
+		function scenario:SetDisplayedTime()
+			-- No-op to avoid fluctuations in the actual runtime breaking the tests
 		end
 
 		testSuite:AddScenario(scenario)


### PR DESCRIPTION
Classic facepalm moment; the times are off by one order of magnitude because I misremembered the SI units (and didn't bother to double-check).