### PR TITLE
Round the times displayed at the end of test runs to at most millisecond precision

### DIFF
--- a/Runtime/API/Testing/Scenario.lua
+++ b/Runtime/API/Testing/Scenario.lua
@@ -185,7 +185,7 @@ function Scenario:GetSummaryText()
 	local coloredSummaryText
 	if failedAssertionCount == 0 then
 		coloredSummaryText =
-			format("%s passing (%.2f ms)", totalAssertionCount - failedAssertionCount, self.runTimeInMilliseconds)
+			format("%s passing (%.0f ms)", totalAssertionCount - failedAssertionCount, self.runTimeInMilliseconds)
 	end
 
 	if failedAssertionCount > 0 then

--- a/Tests/Runtime/API/Testing/TestSuite.spec.lua
+++ b/Tests/Runtime/API/Testing/TestSuite.spec.lua
@@ -146,7 +146,7 @@ describe("TestSuite", function()
 					.. "\t"
 					.. transform.green("✓")
 					.. " "
-					.. "NOOP scenario: 3 passing (0.00 ms)"
+					.. "NOOP scenario: 3 passing (0 ms)"
 					.. "\n\n"
 				expectedConsoleOutput = expectedConsoleOutput
 					.. transform.green("All scenarios completed successfully!")
@@ -194,13 +194,13 @@ describe("TestSuite", function()
 				.. "\t"
 				.. transform.green("✓")
 				.. " "
-				.. "Asserting some stuff: 1 passing (0.00 ms)"
+				.. "Asserting some stuff: 1 passing (0 ms)"
 				.. "\n"
 			expectedConsoleOutput = expectedConsoleOutput
 				.. "\t"
 				.. transform.green("✓")
 				.. " "
-				.. "Asserting some more stuff: 1 passing (0.00 ms)"
+				.. "Asserting some more stuff: 1 passing (0 ms)"
 				.. "\n\n"
 			expectedConsoleOutput = expectedConsoleOutput
 				.. transform.green("All scenarios completed successfully!")


### PR DESCRIPTION
It makes little sense to display sub-millisecond times...