### PR TITLE
Extract code snippets from the unit test suite

### DIFF
--- a/.github/workflows/ci-unix-osx.yml
+++ b/.github/workflows/ci-unix-osx.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Run unit tests
       run: ./evo-luvi test.lua
 
+    - name: Run examples # These examples are synced with the documentation and must always work
+      run: ./evo-luvi run-examples.lua
+
     - name: Run acceptance tests
       run: ./evo-luvi scenarios.lua
 

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Run unit tests
         run: ./evo-luvi test.lua
 
+      - name: Run examples # These examples are synced with the documentation and must always work
+        run: ./evo-luvi run-examples.lua
+
       - name: Run acceptance tests
         run: ./evo-luvi scenarios.lua
 

--- a/run-examples.lua
+++ b/run-examples.lua
@@ -1,0 +1,1 @@
+C_Testing.CreateUnitTestRunner({ "Tests/test-example-snippets.lua" })

--- a/test.lua
+++ b/test.lua
@@ -19,8 +19,6 @@ local testCases = {
 	"Tests/Extensions/table.spec.lua",
 	"Tests/Extensions/transform.spec.lua",
 	"Tests/Extensions/uv.spec.lua",
-	-- The examples should run last as they may spam the console with irrelevant output
-	"Tests/test-example-snippets.lua",
 }
 
 C_Testing.CreateUnitTestRunner(testCases)


### PR DESCRIPTION
Since they may spam the console with irrelevant output, having them run as part of the unit test suite breaks the flow in the console window and makes it more difficult to see at a glance whether any tests have failed.

Of course, it would be possible to just mute the output, but I don't want the examples to run in a modified environment to ensure they' are tested just as they would be running after copy/pasting them straight from the docs.

---

They should still be tested in the CI, just not as part of the unit test suite.