### PR TITLE
Pin the StyLua version to fix autoformat errors

### DIFF
--- a/.github/workflows/autoformat.yaml
+++ b/.github/workflows/autoformat.yaml
@@ -21,10 +21,11 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Set up StyLua
-        uses: JohnnyMorganz/stylua-action@1.0.0
+        uses: JohnnyMorganz/stylua-action@v1.1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --check .
+          args: --check . --verbose
+          version: v0.15.1
 
       - name: Run autoformat
         # Git doesn't like to save the executable bit, apparently... and this is easier than fixing it up manually

--- a/test/extensions/path/test-path-resolve.lua
+++ b/test/extensions/path/test-path-resolve.lua
@@ -6,12 +6,14 @@ local uv = require("uv")
 -- JavaScript is truly a thing of beauty...
 local uv = require("uv")
 local posixyCwd = (ffi.os == "Windows")
-		and ((function()
-			-- cwd will have backslashes, but the posix version must always return slashes (even on Windows systems)
-			local _ = uv.cwd():gsub(path.win32.separator, path.posix.separator)
-			local posixPath = _:sub(_:find(path.posix.separator), #_)
-			return posixPath
-		end)())
+		and (
+			(function()
+				-- cwd will have backslashes, but the posix version must always return slashes (even on Windows systems)
+				local _ = uv.cwd():gsub(path.win32.separator, path.posix.separator)
+				local posixPath = _:sub(_:find(path.posix.separator), #_)
+				return posixPath
+			end)()
+		)
 	or uv.cwd()
 
 local windowsCwd = (function()


### PR DESCRIPTION
They must have changed something, leading to sudden failures when using the "old" 1.0 action with the latest release.