### PR TITLE
Refactor the existing utf8 library tests

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -53,6 +53,7 @@ globals = {
 	"import",
 	"mixin",
 	"path",
+	"utf8", -- Provided by lua-compat-5.3 when using 5.1/LuaJIT
 	"transform",
 
 	-- evo APIs

--- a/Tests/Extensions/utf8.spec.lua
+++ b/Tests/Extensions/utf8.spec.lua
@@ -1,0 +1,27 @@
+describe("utf8", function()
+	local emoji = "🎃"
+
+	describe("len", function()
+		it("should return 1 when an emoji is passed", function()
+			assertEquals(utf8.len(emoji), 1)
+		end)
+	end)
+
+	describe("char", function()
+		it("should return the concatenated unicode byte sequences if an emoji is passed", function()
+			assertEquals(utf8.char(0x1F383), emoji)
+		end)
+	end)
+
+	describe("match", function()
+		it("should return the corresponding unicode character if a valid UTF8 byte sequence is passed", function()
+			assertEquals(emoji:match(utf8.charpattern), emoji)
+		end)
+	end)
+
+	describe("offset", function()
+		it("should return 1 if a single valid unicode character is passed", function()
+			assertEquals(utf8.offset(emoji, 1), 1)
+		end)
+	end)
+end)

--- a/samples/test.app/main.lua
+++ b/samples/test.app/main.lua
@@ -257,14 +257,6 @@ if options.rex then
 	assert(#colors == 3)
 end
 
-print("Testing utf8")
-
-local emoji = "🎃"
-assert(utf8.len(emoji) == 1)
-assert(utf8.char(0x1F383) == emoji)
-assert(emoji:match(utf8.charpattern) == emoji)
-assert(utf8.offset(emoji, 1) == 1)
-
 print("All tests pass!\n")
 
 require("uv").run()

--- a/test.lua
+++ b/test.lua
@@ -18,6 +18,7 @@ local testCases = {
 	"Tests/Extensions/string.spec.lua",
 	"Tests/Extensions/table.spec.lua",
 	"Tests/Extensions/transform.spec.lua",
+	"Tests/Extensions/utf8.spec.lua",
 	"Tests/Extensions/uv.spec.lua",
 }
 


### PR DESCRIPTION
Having them as part of the legacy "samples", which currently also double as (nonstandard) tests, seems a bit messy. It will be much easier to make sure it works and to add more tests when needed if these apps are converted to "regular" tests, so this is a first step in that direction.