### PR TITLE
Update zlib submodule to use the official GitHub repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/luvit/luv.git
 [submodule "deps/zlib"]
 	path = deps/zlib
-	url = https://github.com/luvit/zlib.git
+	url = https://github.com/madler/zlib.git
 [submodule "deps/lua-zlib"]
 	path = deps/lua-zlib
 	url = https://github.com/brimworks/lua-zlib.git


### PR DESCRIPTION
I guess it didn't exist back when the Luvit mirror was created.