### PR TITLE
Add OpenSSL as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "deps/llhttp-ffi"]
 	path = deps/llhttp-ffi
 	url = https://github.com/evo-lua/llhttp-ffi.git
+[submodule "deps/openssl"]
+	path = deps/openssl
+	url = https://github.com/openssl/openssl.git


### PR DESCRIPTION
No need to do fetching at build time. Also, it's more consistent with how the other dependencies are handled.

For now, this does nothing since the legacy CMake build system still fetches the release tarball. But with the new ninja-based build system that will no longer be necessary.

---

Preparation for #98