### PR TITLE
Add PCRE2 as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "deps/openssl"]
 	path = deps/openssl
 	url = https://github.com/openssl/openssl.git
+[submodule "deps/pcre2"]
+	path = deps/pcre2
+	url = https://github.com/PCRE2Project/pcre2.git


### PR DESCRIPTION
This isn't used by the old build system, but it will replace PCRE1 soon (since that's now deprecated).