### PR TITLE
Add a basic test for the luvi.version export

### DIFF
--- a/.github/workflows/ci-unix-osx.yml
+++ b/.github/workflows/ci-unix-osx.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
 
       - name: Install Ninja (via Homebrew)
         run: brew install ninja

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
 
       - name: Set up MSYS2 environment
         uses: msys2/setup-msys2@v2

--- a/Tests/Runtime/luvi.spec.lua
+++ b/Tests/Runtime/luvi.spec.lua
@@ -1,0 +1,15 @@
+describe("luvi", function()
+	local luvi = require("luvi")
+
+	describe("version", function()
+		it("should include a semantic version string", function()
+			-- Technically git describe adds more information in between releases, but it's still "semver-like" enough
+			assertEquals(type(luvi.version), "string")
+
+			local expectedVersionStringPattern = "(v%d+%.%d+%.%d+.*)" --vMAJOR.MINOR.PATCH-optionalGitDescribeSuffix
+			local versionString = string.match(luvi.version, expectedVersionStringPattern)
+
+			assertEquals(type(versionString), "string")
+		end)
+	end)
+end)

--- a/test.lua
+++ b/test.lua
@@ -1,5 +1,6 @@
 local testCases = {
 	"Runtime/LuaEnvironment/CLI.spec.lua",
+	"Tests/Runtime/luvi.spec.lua",
 	"Tests/Runtime/LuviAppBundle.spec.lua",
 	"Tests/Runtime/API/BuildTools/NinjaFile.spec.lua",
 	"Tests/Runtime/API/BuildTools/C_BuildTools.spec.lua",


### PR DESCRIPTION
If the ``LUVI_VERSION`` define isn't set this will fail. And yes, that has happened to me more than once...

Edit: Also fails on the CI runner if only a shallow clone is used. There are some potential issues with fetching the entire history, but I estimate they're not going to be problematic in the context of this project. See commit messages for details.