### PR TITLE
Remove the old PCRE1 repository from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "deps/lrexlib"]
 	path = deps/lrexlib
 	url = https://github.com/rrthomas/lrexlib.git
-[submodule "deps/pcre"]
-	path = deps/pcre
-	url = https://github.com/luvit/pcre.git
 [submodule "deps/lpeg"]
 	path = deps/lpeg
 	url = https://github.com/roberto-ieru/LPeg.git


### PR DESCRIPTION
The new build system won't be using it, as PCRE2 is officially the recommended option nowadays (and I don't have any legacy code that requires shipping PCRE1).

Obviously this can't be merged until the ninja-based build system is in place.