### PR TITLE
Streamline the displayed text for uv tests

### DIFF
--- a/Tests/Extensions/uv.spec.lua
+++ b/Tests/Extensions/uv.spec.lua
@@ -1,4 +1,4 @@
-describe("Extensions: uv library", function()
+describe("uv", function()
 	describe("errors", function()
 		it("should export human-readable error messages for all libuv error constants", function()
 			local expectedErrorConstants = {


### PR DESCRIPTION
I guess I was thinking of a different convention when I wrote this, but it's now grossly inconsistent with all the other tests that came afterwards.