### PR TITLE
Add a default value for the LUVI_VERSION define

### DIFF
--- a/Runtime/luvi.c
+++ b/Runtime/luvi.c
@@ -17,16 +17,18 @@
 
 #include "./luvi.h"
 
+#ifndef LUVI_VERSION
+#define LUVI_VERSION "dev-untagged"
+#endif
+
 LUALIB_API int luaopen_luvi(lua_State* L)
 {
 #if defined(WITH_OPENSSL) || defined(WITH_PCRE)
 	char buffer[1024];
 #endif
 	lua_newtable(L);
-#ifdef LUVI_VERSION
 	lua_pushstring(L, "" LUVI_VERSION "");
 	lua_setfield(L, -2, "version");
-#endif
 	lua_newtable(L);
 #ifdef WITH_OPENSSL
 	snprintf(buffer, sizeof(buffer), "%s, lua-openssl %s",


### PR DESCRIPTION
If the version cannot be obtained from git, there should be a placeholder available that can be displayed in the CLI without errors.

Unit tests can then make sure that the format itself is adhered to, meaning CI failures when the version wasn't properly embedded. Without this, it would also fail but the error message would be less clear ("random" Lua error).