### PR TITLE
Streamline the llhttp include mechanism

### DIFF
--- a/Runtime/Bindings/llhttp_ffi.c
+++ b/Runtime/Bindings/llhttp_ffi.c
@@ -1,4 +1,5 @@
 #include "llhttp.h"
+#include "lua.h"
 
 struct static_llhttp_exports_table {
 	void (*llhttp_init)(llhttp_t* parser, llhttp_type_t type, const llhttp_settings_t* settings);

--- a/Runtime/Bindings/llhttp_ffi.h
+++ b/Runtime/Bindings/llhttp_ffi.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "lua.h"
+
+const char* llhttp_get_version_string(void);
+void export_llhttp_bindings(lua_State* L);

--- a/Runtime/luvi.c
+++ b/Runtime/luvi.c
@@ -16,6 +16,7 @@
  */
 
 #include "./luvi.h"
+#include "Bindings/llhttp_ffi.h"
 
 LUALIB_API int luaopen_luvi(lua_State* L)
 {

--- a/Runtime/main.c
+++ b/Runtime/main.c
@@ -17,9 +17,9 @@
 
 #define LUA_LIB
 #include "luv.h"
-#include "Bindings/llhttp_ffi.c"
 #include "luvi.c"
 #include "luvi.h"
+#include "Bindings/llhttp_ffi.h"
 #ifndef MINIZ_NO_STDIO
 #define MINIZ_NO_STDIO
 #endif


### PR DESCRIPTION
Including C files directly isn't a good practice (or so the experts say). Let's not do that from now on.

As for header guards: pragma once is fine since I don't care one bit about ancient compilers. The end.

Edit: I guess it doesn't work with the legacy CMake build system. I'll merge and rebase it later, then.

Edit 2: Nevermind, I guess I need it in the ninja build branch or else I have to duplicate the changes.