### PR TITLE
Fix a typo in the unixbuild-all script

### DIFF
--- a/deps/unixbuild-all.sh
+++ b/deps/unixbuild-all.sh
@@ -4,4 +4,4 @@ deps/openssl-unixbuild.sh
 deps/luaopenssl-unixbuild.sh
 deps/luv-unixbuild.sh
 deps/zlib-unixbuild.sh
-deps/pcre2-unixbuild.sh
+deps/pcre-unixbuild.sh


### PR DESCRIPTION
Since the all-in-one build scripts aren't tested via CI currently (to get more fine-grained steps), this slipped through the cracks.