### PR TITLE
Add a script for exporting the dependency graph

### DIFF
--- a/deps/export-dependency-graph.sh
+++ b/deps/export-dependency-graph.sh
@@ -1,0 +1,2 @@
+# This should be run after the build scripts, as it requires a ninja file to be present
+ninja -t graph | dot -Tpng -odependency-graph.png


### PR DESCRIPTION
This can help understand the ninja build process better, and may even be auto-generated and placed in the documentation?

The only caveat: Dependencies built ahead-of-time aren't included as there are no build edges for them in the generated ninja file.