### PR TITLE
Update the displayed executable name

### DIFF
--- a/Runtime/LuaEnvironment/CLI.lua
+++ b/Runtime/LuaEnvironment/CLI.lua
@@ -151,6 +151,6 @@ CLI.COMMAND_HANDLERS = {
 	["--help"] = "help",
 }
 
-CLI.EXECUTABLE_NAME = "evo-luvi"
+CLI.EXECUTABLE_NAME = "evo"
 
 return CLI


### PR DESCRIPTION
Shouldn't this use uv.exepath? Oh well, doesn't matter...