### PR TITLE
Update zlib build scripts to also copy zconf.h

### DIFF
--- a/deps/zlib-unixbuild.sh
+++ b/deps/zlib-unixbuild.sh
@@ -8,3 +8,4 @@ cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPI
 cmake --build $BUILD_DIR --clean-first
 
 cp $BUILD_DIR/libz.a $OUT_DIR/zlibstatic.a
+cp $BUILD_DIR/zconf.h $OUT_DIR

--- a/deps/zlib-windowsbuild.sh
+++ b/deps/zlib-windowsbuild.sh
@@ -8,3 +8,4 @@ cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPI
 cmake --build $BUILD_DIR --clean-first
 
 cp $BUILD_DIR/libzlibstatic.a $OUT_DIR/zlibstatic.a
+cp $BUILD_DIR/zconf.h $OUT_DIR


### PR DESCRIPTION
It seems that this header was somehow detected automatically in the CI (and on my machine).

Trying to install the runtime from scratch on a fresh WSL distro shows that the header is not, in fact, always present and so it should certainly be copied.