### PR TITLE
Enable the -g flag globally for generated LuaJIT bytecode objects

### DIFF
--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -153,7 +153,7 @@ function EvoBuildTarget:SetLuaBytecodeGenerator()
 
 	ninjaFile:AddRule(
 		"bcsave",
-		"$LUAJIT_EXECUTABLE -b $in $out",
+		"$LUAJIT_EXECUTABLE -bg $in $out",
 		{ description = "Saving LuaJIT bytecode for $in ..." }
 	)
 


### PR DESCRIPTION
Since the overhead for carrying around those debug symbols is minimal and having readable stack traces makes life so much less annoying, let's just add this flag unconditionally and see where that leads.