### PR TITLE
Improve stack traces originating in main.c

### DIFF
--- a/Runtime/luvi.h
+++ b/Runtime/luvi.h
@@ -47,3 +47,7 @@ int luaopen_lpeg(lua_State* L);
 
 void luvi_openlibs(lua_State* L);
 #endif
+
+#define TOSTRING(x) #x
+#define STRINGIFY(x) TOSTRING(x)
+#define DEBUG_FILE_LOCATION __FILE__ ":" STRINGIFY(__LINE__)

--- a/Runtime/main.c
+++ b/Runtime/main.c
@@ -151,7 +151,8 @@ int main(int argc, char* argv[])
 	errfunc = lua_gettop(L);
 
 	// Load the init.lua script
-	if (luaL_loadstring(L, "return require('init')(...)")) {
+	const char* entry_point = "return require('init')(...)";
+	if (luaL_loadbuffer(L, entry_point, strlen(entry_point), "=(Lua entry point, at " DEBUG_FILE_LOCATION ")")) {
 		fprintf(stderr, "%s\n", lua_tostring(L, -1));
 		vm_release(L);
 		return -1;


### PR DESCRIPTION
This only catches errors inside the statically-linked bytecode objects, not those triggered via loadfile (in import or the init script itself). But still, it's a bit of an improvement since it no longer prints the entire string passed as the chunk name...