### PR TITLE
Add support for string buffers to the assertEquals builtin

### DIFF
--- a/Runtime/LuaEnvironment/extensions/assertions.lua
+++ b/Runtime/LuaEnvironment/extensions/assertions.lua
@@ -23,10 +23,10 @@ local function assertDeepStrictEquals(actual, expected, description)
 end
 
 function assertEquals(actual, expected, description)
-	if actual == "" then
+	if actual == "" or tostring(actual) == "" then
 		actual = "<empty string>"
 	end
-	if expected == "" then
+	if expected == "" or tostring(expected) == "" then
 		expected = "<empty string>"
 	end
 

--- a/Tests/Extensions/assertEquals.spec.lua
+++ b/Tests/Extensions/assertEquals.spec.lua
@@ -88,4 +88,19 @@ describe("assertEquals", function()
 
 		_G.ERROR = originalErrorHandler
 	end)
+
+	it("should return true if comparing a string and a buffer with the same contents", function()
+		local str = "hello"
+		local buffer = require("string.buffer").new()
+		buffer:put("hello")
+
+		assertEquals(str, buffer)
+	end)
+
+	it("should return true if comparing an empty string and an empty string buffer", function()
+		local str = ""
+		local buffer = require("string.buffer").new()
+
+		assertEquals(str, buffer)
+	end)
 end)


### PR DESCRIPTION
LuaJIT internally converts the buffer contents to strings, so we might as well consider them equivalent for string comparisons.

---

This is a prerequisite for #90 since the FFI layer makes heavy use of string buffers and I can't add tests for that code otherwise.