### PR TITLE
Add a global extend builtin to cut down on redundant OOP code

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -50,6 +50,7 @@ globals = {
 	"EMERGENCY",
 
 	-- Nonstandard extensions
+	"extend",
 	"import",
 	"mixin",
 	"path",

--- a/Runtime/LuaEnvironment/primitives.lua
+++ b/Runtime/LuaEnvironment/primitives.lua
@@ -27,6 +27,9 @@ local primitives = {
 		require("AsyncStreamMixin")
 		require("AsyncSocketMixin")
 	end,
+	extend = function()
+		return require("extend")
+	end,
 }
 
 return primitives

--- a/Runtime/LuaEnvironment/primitives/extend.lua
+++ b/Runtime/LuaEnvironment/primitives/extend.lua
@@ -1,0 +1,24 @@
+local getmetatable = getmetatable
+local setmetatable = setmetatable
+local pairs = pairs
+local type = type
+
+local function extend(child, parent)
+	local parentMetatable = getmetatable(parent)
+
+	if type(parentMetatable) ~= "table" then
+		setmetatable(parent, {})
+		parentMetatable = getmetatable(parent)
+	end
+
+	local childMetatable = {}
+	for key, value in pairs(parentMetatable) do
+		childMetatable[key] = value
+	end
+
+	childMetatable.__index = parent
+
+	setmetatable(child, childMetatable)
+end
+
+_G.extend = extend

--- a/Tests/Primitives/extend.spec.lua
+++ b/Tests/Primitives/extend.spec.lua
@@ -1,0 +1,34 @@
+describe("extend", function()
+	it("should still work if the prototype object doesn't have a metatable", function()
+		local child = {}
+		local parent = {}
+		function parent:hello() end
+
+		extend(child, parent)
+		assertEquals(child.hello, parent.hello)
+	end)
+
+	it("should set up a metatable such that the child inherits the prototype's functionality", function()
+		local child = {}
+		local parent = {}
+		function parent:thisFunctionShouldBeInherited() end
+
+		extend(child, parent)
+		assertEquals(child.thisFunctionShouldBeInherited, parent.thisFunctionShouldBeInherited)
+	end)
+
+	it("should copy all existing fields from the prototype's metatable", function()
+		local child = {}
+		local parent = {}
+		local parentOfParent = {}
+		function parent:thisFunctionShouldBeInherited() end
+		function parentOfParent:thisFunctionShouldAlsoBeInherited() end
+
+		extend(parent, parentOfParent)
+		extend(child, parent)
+
+		assertEquals(child.thisFunctionShouldBeInherited, parent.thisFunctionShouldBeInherited)
+		assertEquals(child.thisFunctionShouldAlsoBeInherited, parentOfParent.thisFunctionShouldAlsoBeInherited)
+		assertEquals(parent.thisFunctionShouldAlsoBeInherited, parentOfParent.thisFunctionShouldAlsoBeInherited)
+	end)
+end)

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -25,6 +25,7 @@ local EvoBuildTarget = {
 		"Runtime/LuaEnvironment/primitives.lua",
 		"Runtime/LuaEnvironment/primitives/aliases.lua",
 		"Runtime/LuaEnvironment/primitives/dump.lua",
+		"Runtime/LuaEnvironment/primitives/extend.lua",
 		"Runtime/LuaEnvironment/primitives/v8_string.lua",
 		"Runtime/LuaEnvironment/primitives/logging.lua",
 		"Runtime/LuaEnvironment/primitives/virtual_file_system.lua",

--- a/test.lua
+++ b/test.lua
@@ -10,6 +10,7 @@ local testCases = {
 	"Tests/Runtime/API/Testing/Scenario.spec.lua",
 	"Tests/Runtime/API/Testing/TestSuite.spec.lua",
 	"Tests/Runtime/API/Networking/C_Networking.spec.lua",
+	"Tests/Primitives/extend.spec.lua",
 	"Tests/Primitives/format.spec.lua",
 	"Tests/Primitives/logging.spec.lua",
 	"Tests/Primitives/printf.spec.lua",


### PR DESCRIPTION
This complements ``mixin`` nicely and avoids having to write boilerplate OOP code wherever simple inheritance is needed.