### PR TITLE
Move the SIGPIPE handling code to LuaMain

### DIFF
--- a/Runtime/API/Networking/TcpServer.lua
+++ b/Runtime/API/Networking/TcpServer.lua
@@ -42,13 +42,6 @@ function TcpServer:Construct(creationOptions)
 
 	setmetatable(instance, self)
 
-	-- An unhandled SIGPIPE error signal will crash the server on platforms that send it, e.g. when attempting to write to a closed socket
-	if uv.constants.SIGPIPE then
-		local sigpipeSignal = uv.new_signal()
-		sigpipeSignal:start("sigpipe")
-		uv.unref(sigpipeSignal) -- This empty signal handler shouldn't prevent the event loop from exiting as it's a no-op
-	end
-
 	instance:StartListening()
 
 	return instance

--- a/Runtime/LuaEnvironment/init.lua
+++ b/Runtime/LuaEnvironment/init.lua
@@ -92,6 +92,10 @@ function Luvi:LuaMain(commandLineArgumentsPassedFromC)
 		local sigpipeSignal = uv.new_signal()
 		sigpipeSignal:start("sigpipe")
 		uv.unref(sigpipeSignal) -- This empty signal handler shouldn't prevent the event loop from exiting as it's a no-op
+
+		-- May want to remove the handler again, so let's make finding it trivial
+		local luvi = require("luvi")
+		luvi.signals.SIGPIPE = sigpipeSignal
 	end
 
 	return self:StartCommandLineParser()

--- a/Runtime/LuaEnvironment/init.lua
+++ b/Runtime/LuaEnvironment/init.lua
@@ -87,6 +87,13 @@ function Luvi:LuaMain(commandLineArgumentsPassedFromC)
 		return self:StartBundledApp()
 	end
 
+	-- An unhandled SIGPIPE error signal will crash the server on platforms that send it, e.g. when attempting to write to a closed socket
+	if uv.constants.SIGPIPE then
+		local sigpipeSignal = uv.new_signal()
+		sigpipeSignal:start("sigpipe")
+		uv.unref(sigpipeSignal) -- This empty signal handler shouldn't prevent the event loop from exiting as it's a no-op
+	end
+
 	return self:StartCommandLineParser()
 end
 

--- a/Runtime/luvi.c
+++ b/Runtime/luvi.c
@@ -28,6 +28,11 @@ LUALIB_API int luaopen_luvi(lua_State* L)
 	lua_newtable(L);
 	lua_pushstring(L, "" LUVI_VERSION "");
 	lua_setfield(L, -2, "version");
+
+	// Can use this to store dereferenced signal handles (for testing and debugging purposes)
+	lua_newtable(L);
+	lua_setfield(L, -2, "signals");
+
 	lua_newtable(L);
 	snprintf(buffer, sizeof(buffer), "%s, lua-openssl %s",
 		SSLeay_version(SSLEAY_VERSION), LOPENSSL_VERSION);

--- a/Tests/Runtime/luvi.spec.lua
+++ b/Tests/Runtime/luvi.spec.lua
@@ -12,4 +12,21 @@ describe("luvi", function()
 			assertEquals(type(versionString), "string")
 		end)
 	end)
+
+	describe("signals", function()
+		it("should be exported even if there are no dereferenced signal handlers", function()
+			assertEquals(type(luvi.signals), "table")
+		end)
+
+		it("should store the dereferenced SIGPIPE handler when one is required", function()
+			local uv = require("uv")
+			-- This is a no-op on Windows
+			if not uv.constants.SIGPIPE then
+				return
+			end
+
+			local sigpipeHandler = luvi.signals.SIGPIPE
+			assertEquals(type(sigpipeHandler), "userdata")
+		end)
+	end)
 end)


### PR DESCRIPTION
Creating just one handler in the runtime regardless of TCP server instances makes it less likely there will be issues when creating multiple servers, or HTTP/WebSocket servers down the line.