### PR TITLE
Add a missing label for the llhttp-ffi test suite

### DIFF
--- a/Tests/Extensions/llhttp.spec.lua
+++ b/Tests/Extensions/llhttp.spec.lua
@@ -5,32 +5,34 @@ describe("llhttp", function()
 		assertEquals(type(llhttp), "table")
 	end)
 
-	it("should export all of the llhttp-ffi API", function()
-		local exportedApiSurface = {
-			"llhttp_init",
-			"llhttp_reset",
-			"llhttp_settings_init",
-			"llhttp_execute",
-			"llhttp_finish",
-			"llhttp_message_needs_eof",
-			"llhttp_should_keep_alive",
-			"llhttp_pause",
-			"llhttp_resume",
-			"llhttp_resume_after_upgrade",
-			"llhttp_get_errno",
-			"llhttp_get_error_reason",
-			"llhttp_set_error_reason",
-			"llhttp_get_error_pos",
-			"llhttp_errno_name",
-			"llhttp_method_name",
-			"llhttp_set_lenient_headers",
-			"llhttp_set_lenient_chunked_length",
-			"llhttp_set_lenient_keep_alive",
-		}
+	describe("bindings", function()
+		it("should export all of the llhttp-ffi API", function()
+			local exportedApiSurface = {
+				"llhttp_init",
+				"llhttp_reset",
+				"llhttp_settings_init",
+				"llhttp_execute",
+				"llhttp_finish",
+				"llhttp_message_needs_eof",
+				"llhttp_should_keep_alive",
+				"llhttp_pause",
+				"llhttp_resume",
+				"llhttp_resume_after_upgrade",
+				"llhttp_get_errno",
+				"llhttp_get_error_reason",
+				"llhttp_set_error_reason",
+				"llhttp_get_error_pos",
+				"llhttp_errno_name",
+				"llhttp_method_name",
+				"llhttp_set_lenient_headers",
+				"llhttp_set_lenient_chunked_length",
+				"llhttp_set_lenient_keep_alive",
+			}
 
-		for _, functionName in ipairs(exportedApiSurface) do
-			assertEquals(type(llhttp.bindings[functionName]), "cdata", "Should bind function " .. functionName)
-		end
+			for _, functionName in ipairs(exportedApiSurface) do
+				assertEquals(type(llhttp.bindings[functionName]), "cdata", "Should bind function " .. functionName)
+			end
+		end)
 	end)
 
 	describe("initialize", function()


### PR DESCRIPTION
It's just a cosmetic change, but I want the test output to be consistent.