### PR TITLE
Add automatic changelog generation capabilities to the C_BuildTools API

### DIFF
--- a/.github/workflows/ci-unix-osx.yml
+++ b/.github/workflows/ci-unix-osx.yml
@@ -74,11 +74,16 @@ jobs:
       - name: Prepare artifacts (${{ matrix.os }})
         run: cp evo evo-${{ matrix.os }}-amd64
 
+      # GitHub adds a heading of their own, so remove the duplicate
+      - name: Generate CHANGELOG.MD
+        run: ./evo create-changelog.lua && tail -n +3 CHANGELOG.MD > CHANGELOG-GITHUB.MD && mv CHANGELOG-GITHUB.MD CHANGELOG.MD
+
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
           files: evo-${{ matrix.os }}-amd64
+          body_path: CHANGELOG.MD
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -68,11 +68,16 @@ jobs:
       - name: Run acceptance tests
         run: ./evo scenarios.lua
 
+      # GitHub adds a heading of their own, so remove the duplicate
+      - name: Generate CHANGELOG.MD
+        run: ./evo create-changelog.lua && tail -n +3 CHANGELOG.MD > CHANGELOG-GITHUB.MD && mv CHANGELOG-GITHUB.MD CHANGELOG.MD
+
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
           files: evo.exe
+          body_path: CHANGELOG.MD
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ luvi
 .ninja_deps
 .ninja_log
 build.ninja
+CHANGELOG.MD

--- a/Runtime/API/BuildTools/C_BuildTools.lua
+++ b/Runtime/API/BuildTools/C_BuildTools.lua
@@ -18,6 +18,14 @@ local C_BuildTools = {
 		C_ARCHIVER = "ar",
 		ARCHIVER_FLAGS = "-rcs",
 	},
+	SEMANTIC_VERSION_STRING_PATTERN = "(v(%d+)%.(%d+)%.(%d+).*)", --vMAJOR.MINOR.PATCH-optionalGitDescribeSuffix
+	GITHUB_REPOSITORY_URL = "https://github.com/evo-lua/evo-luvi",
+	CHANGELOG_FILE_PATH = "CHANGELOG.MD",
+	PROJECT_AUTHORS = {
+		-- This is only useful to exclude myself from the auto-generated changelog. No one cares otherwise - it's the work that matters ;)
+		"Duckwhale", -- The humble author's GitHub name
+		"RDW", -- The humble author's Discord name (stored in my local git config)
+	},
 }
 
 function C_BuildTools.GetStaticLibraryName(libraryBaseName)
@@ -32,17 +40,224 @@ function C_BuildTools.GetExecutableName(libraryBaseName)
 	return libraryBaseName .. C_BuildTools.EXECUTABLE_FILE_EXTENSION
 end
 
-function C_BuildTools.DiscoverGitVersionTag()
-	local gitDescribeCommand = "git describe --tags"
+function C_BuildTools.GetOutputFromShellCommand(shellCommand)
+	local file = assert(io.popen(shellCommand, "r"))
 
-	local file = assert(io.popen(gitDescribeCommand, "r"))
 	file:flush() -- Required to prevent receiving only partial output
 	local output = file:read("*all")
 	file:close()
 
-	-- Strip final newline since that's not very useful outside of the shell
-	output = string.sub(output, 0, string.len(output) - 1)
 	return output
+end
+
+function C_BuildTools.DiscoverPreviousGitVersionTag()
+	-- Need to exclude non-versioned tags, but git tag can't do the filtering by itself...
+	local gitDescribeCommand = "git tag --sort=-creatordate | grep v[0-9]*.[0-9]*.[0-9]* | head -1"
+	local versionTag = C_BuildTools.GetOutputFromShellCommand(gitDescribeCommand)
+
+	-- Strip final newline since that's not very useful outside of the shell
+	versionTag = string.sub(versionTag, 0, string.len(versionTag) - 1)
+
+	return versionTag
+end
+
+function C_BuildTools.DiscoverGitVersionTag()
+	-- Need to exclude non-versioned tags
+	local gitDescribeCommand = "git describe --tags --match='v[0-9]*.[0-9]*.[0-9]*'"
+	local versionTag = C_BuildTools.GetOutputFromShellCommand(gitDescribeCommand)
+
+	-- Strip final newline since that's not very useful outside of the shell
+	versionTag = string.sub(versionTag, 0, string.len(versionTag) - 1)
+
+	return versionTag
+end
+
+function C_BuildTools.DiscoverMergeCommitsBetween(oldVersion, newVersion)
+	if oldVersion == newVersion then
+		return {}
+	end
+
+	-- This is the format string used by NodeJS changelogs, but modified to display shorter hashes
+	local gitDescribeCommand = "git log "
+		.. oldVersion
+		.. "..."
+		.. newVersion
+		.. " --merges --pretty='format:* \\[[`%h`]("
+		.. C_BuildTools.GITHUB_REPOSITORY_URL
+		.. "/commit/%H)] - %b'"
+
+	local commits = C_BuildTools.GetOutputFromShellCommand(gitDescribeCommand)
+	commits = string.explode(commits, "\n") -- By default, Git outputs one commit per line
+
+	return commits
+end
+
+function C_BuildTools.DiscoverCommitAuthorsBetween(oldVersion, newVersion)
+	local gitLogCommand = 'git log --pretty=format:"%an" v3.0.0..v3.1.0 | sort | uniq'
+
+	local committers = C_BuildTools.GetOutputFromShellCommand(gitLogCommand)
+	committers = string.explode(committers, "\n") -- By default, git log outputs one entry per line
+
+	return committers
+end
+
+-- This would be cleaner if we kept the PROJECT_AUTHORS as an array, but then we'd still need to iterate and check the values...
+local function convertArrayToSet(arrayTable)
+	local setTable = {}
+
+	for index, value in ipairs(arrayTable) do
+		setTable[value] = true
+	end
+
+	return setTable
+end
+
+function C_BuildTools.DiscoverExternalContributorsBetween(oldVersion, newVersion)
+	local committers = C_BuildTools.DiscoverCommitAuthorsBetween(oldVersion, newVersion)
+
+	local externalContributors = {}
+
+	for index, authorName in ipairs(committers) do -- Conveniently already sorted alphabetically if we use ipairs after piping to sort
+		local isProjectAuthor = convertArrayToSet(C_BuildTools.PROJECT_AUTHORS)[authorName]
+		-- The changelog should list all external contributors, to show appreciation for their work
+		-- No point in self-aggrandizing by adding the project authors (i.e., myself) to every change log...
+		if not isProjectAuthor then
+			externalContributors[#externalContributors + 1] = authorName
+		end
+	end
+
+	return externalContributors
+end
+
+function C_BuildTools.GetChangelogEntry(oldVersion, newVersion)
+	local notableChanges = C_BuildTools.FetchNotableChanges(newVersion)
+
+	if not notableChanges then
+		return {}
+	end
+
+	local changelogEntry = {
+		versionTag = newVersion,
+		newFeatures = notableChanges.newFeatures or {},
+		improvements = notableChanges.improvements or {},
+		breakingChanges = notableChanges.breakingChanges or {},
+		pullRequests = C_BuildTools.DiscoverMergeCommitsBetween(oldVersion, newVersion) or {},
+		contributors = notableChanges.contributors
+			or C_BuildTools.DiscoverExternalContributorsBetween(oldVersion, newVersion),
+	}
+
+	return changelogEntry
+end
+
+function C_BuildTools.FetchNotableChanges(versionTag)
+	-- Defer loading since this isn't generally useful and might take up more space eventually
+	local notableChanges = require("changelog")
+	return notableChanges[versionTag] or {}
+end
+
+-- This is screaming to get out and become its own class, but for the time being it shall remain imprisoned...
+local function markdownFile_AddCategory(markdownFile, category)
+	if #category.entries == 0 then
+		-- We don't want to list empty categories now, do we?
+		return markdownFile
+	end
+
+	markdownFile = markdownFile .. format("### %s\n\n", category.name)
+
+	for k, v in ipairs(category.entries) do
+		markdownFile = markdownFile .. "* " .. v .. "\n"
+	end
+
+	markdownFile = markdownFile .. "\n"
+
+	return markdownFile
+end
+
+function C_BuildTools.StringifyChangelogContents(changelogEntry)
+	local markdownFile = "# " .. changelogEntry.versionTag .. "\n\n"
+
+	local changelogCategories = {
+		-- The order that categories appear in is important, so this has to be an array (even if it's more verbose)
+		{
+			name = "New Features",
+			entries = changelogEntry.newFeatures,
+		},
+		{
+			name = "Improvements",
+			entries = changelogEntry.improvements,
+		},
+		{
+			name = "Breaking Changes",
+			entries = changelogEntry.breakingChanges,
+		},
+	}
+
+	for index, category in ipairs(changelogCategories) do
+		markdownFile = markdownFile_AddCategory(markdownFile, category)
+	end
+
+	-- The format for pull requests is derived from git console output, so let's not touch that (fow now)
+	markdownFile = markdownFile .. "### Pull Requests\n\n" .. table.concat(changelogEntry.pullRequests, "\n") .. "\n\n"
+
+	markdownFile = markdownFile .. "#### Contributors (in alphabetical order)\n\n"
+
+	if #changelogEntry.contributors == 0 then
+		markdownFile = markdownFile .. "* No external contributors"
+	end
+
+	-- This is also somewhat messy due to the PRs needing to be displayed first - for now it'll have to do though
+	local contributors = { name = "Contributors (in alphabetical order)", entries = changelogEntry.contributors }
+	markdownFile = markdownFile_AddCategory(markdownFile, contributors)
+
+	return markdownFile
+end
+
+function C_BuildTools.GenerateChangeLog(from, to)
+	local currentVersionTag = C_BuildTools.DiscoverGitVersionTag()
+	local previousVersionTag = C_BuildTools.DiscoverPreviousGitVersionTag()
+
+	previousVersionTag = from or previousVersionTag
+	currentVersionTag = to or currentVersionTag
+
+	DEBUG("Generating changelog for release " .. transform.green(currentVersionTag))
+	DEBUG(
+		"Including changes from " .. transform.green(previousVersionTag) .. " to " .. transform.green(currentVersionTag)
+	)
+
+	local changes = C_BuildTools.GetChangelogEntry(previousVersionTag, currentVersionTag)
+	local markdownChanges = C_BuildTools.StringifyChangelogContents(changes)
+
+	DEBUG("Changelog summary:")
+
+	local numPullRequests = #changes.pullRequests
+	if numPullRequests == 0 then
+		numPullRequests = "NO"
+	end
+	local numFeatures = #changes.newFeatures
+	if numFeatures == 0 then
+		numFeatures = "NO"
+	end
+	local numImprovements = #changes.improvements
+	if numImprovements == 0 then
+		numImprovements = "NO"
+	end
+	local numBreakingChanges = #changes.breakingChanges
+	if numBreakingChanges == 0 then
+		numBreakingChanges = "NO"
+	end
+	local numContributors = #changes.contributors
+	if numContributors == 0 then
+		numContributors = "NO"
+	end
+
+	DEBUG(format("* %s new feature%s", numFeatures, numFeatures == 1 and "" or "s"))
+	DEBUG(format("* %s improvement%s", numImprovements, numImprovements == 1 and "" or "s"))
+	DEBUG(format("* %s breaking change%s", numBreakingChanges, numBreakingChanges == 1 and "" or "s"))
+	DEBUG(format("* %s pull request%s", numPullRequests, numPullRequests == 1 and "" or "s"))
+	DEBUG(format("* %s external contributor%s", numContributors, numContributors == 1 and "" or "s"))
+	DEBUG("Saving changelog as " .. transform.green(C_BuildTools.CHANGELOG_FILE_PATH))
+
+	C_FileSystem.WriteFile(C_BuildTools.CHANGELOG_FILE_PATH, markdownChanges)
 end
 
 return C_BuildTools

--- a/Tests/Runtime/API/BuildTools/C_BuildTools.spec.lua
+++ b/Tests/Runtime/API/BuildTools/C_BuildTools.spec.lua
@@ -2,6 +2,26 @@ local C_BuildTools = import("../../../../Runtime/API/BuildTools/C_BuildTools.lua
 
 local ffi = require("ffi")
 
+local function assertString(value)
+	local actualType = type(value)
+	local expectedType = "string"
+
+	if actualType ~= expectedType then
+		error(
+			transform.brightRedBackground(
+				format(
+					'Expected value %s to be of type "%s", but the actual type is "%s"',
+					value,
+					expectedType,
+					actualType
+				)
+			),
+			2
+		)
+	end
+	assertEquals(actualType, expectedType)
+end
+
 describe("C_BuildTools", function()
 	describe("GetStaticLibraryName", function()
 		it("should return a standardized library name on all supported systems", function()
@@ -60,6 +80,234 @@ describe("C_BuildTools", function()
 			local standardizedLibraryName = C_BuildTools.GetExecutableName(libraryBaseName)
 			local expectedLibraryName = expectedLibraryNamesPerOS[ffi.os]
 			assertEquals(standardizedLibraryName, expectedLibraryName)
+		end)
+	end)
+
+	describe("GetOutputFromShellCommand", function()
+		it("should return the process output in full when running a valid shell command", function()
+			local command = "echo test"
+			local expectedOutput = "test\n"
+			local actualOutput = C_BuildTools.GetOutputFromShellCommand(command)
+			assertEquals(actualOutput, expectedOutput)
+		end)
+	end)
+
+	describe("DiscoverGitVersionTag", function()
+		it("should return a single semantic version string", function()
+			local gitVersionString = C_BuildTools.DiscoverGitVersionTag()
+			assertString(gitVersionString)
+
+			local semanticVersionString, major, minor, patch =
+				string.match(gitVersionString, C_BuildTools.SEMANTIC_VERSION_STRING_PATTERN)
+			assertString(semanticVersionString)
+			assertString(major)
+			assertString(minor)
+			assertString(patch)
+		end)
+	end)
+
+	describe("DiscoverPreviousGitVersionTag", function()
+		it("should return a single semantic version string", function()
+			local gitVersionString = C_BuildTools.DiscoverPreviousGitVersionTag()
+			assertString(gitVersionString)
+
+			print(gitVersionString)
+
+			local semanticVersionString, major, minor, patch =
+				string.match(gitVersionString, C_BuildTools.SEMANTIC_VERSION_STRING_PATTERN)
+			assertString(semanticVersionString)
+			assertString(major)
+			assertString(minor)
+			assertString(patch)
+		end)
+	end)
+
+	describe("DiscoverCommitAuthorsBetween", function()
+		it("should return all committers if two valid version tags are given", function()
+			local oldVersionTag = "v3.0.0"
+			local newVersionTag = "v3.1.0"
+			local authors = C_BuildTools.DiscoverCommitAuthorsBetween(oldVersionTag, newVersionTag)
+
+			-- Hardcoding these isn't great, but they aren't expected to ever change ("The history is immutable", yatta yatta)
+			local expectedAuthors = C_BuildTools.PROJECT_AUTHORS
+			assertEquals(authors, expectedAuthors)
+		end)
+	end)
+
+	describe("DiscoverExternalContributorsBetween", function()
+		it("should return all external committers if two valid version tags are given", function()
+			local oldVersionTag = "v3.0.0"
+			local newVersionTag = "v3.1.0"
+			local authors = C_BuildTools.DiscoverExternalContributorsBetween(oldVersionTag, newVersionTag)
+
+			-- Hardcoding these isn't great, but they aren't expected to ever change ("The history is immutable", yatta yatta)
+			local expectedAuthors = {}
+			assertEquals(authors, expectedAuthors)
+		end)
+	end)
+
+	describe("DiscoverMergeCommitsBetween", function()
+		it("should return an empty table if both version tags are identical", function()
+			local versionTag = "v3.0.0"
+			local commits = C_BuildTools.DiscoverMergeCommitsBetween(versionTag, versionTag)
+			assertEquals(commits, {})
+		end)
+
+		it("should return all relevant merge commits if two valid version tags are given", function()
+			local oldVersionTag = "v3.0.0"
+			local newVersionTag = "v3.1.0"
+			local commits = C_BuildTools.DiscoverMergeCommitsBetween(oldVersionTag, newVersionTag)
+
+			-- Hardcoding these isn't great, but they aren't expected to ever change ("The history is immutable", yatta yatta)
+			local expectedCommits = {
+				"* \\[[`ce0ec6d`](https://github.com/evo-lua/evo-luvi/commit/ce0ec6d6b7cd3fe35144f1c720c95ef9747777d7)] - Add TCP_BACKPRESSURE related events to the TCP client and server builtins",
+				"* \\[[`07e5b99`](https://github.com/evo-lua/evo-luvi/commit/07e5b9918a181b08cfc8db8e73e3019f479c72fe)] - Add a standardized way for handling empty EOF chunks to the TCP Socket builtins",
+				"* \\[[`79ce363`](https://github.com/evo-lua/evo-luvi/commit/79ce3637a427018569138095d4a57abc12f15ea9)] - Refactor the luvi library exports",
+				"* \\[[`2406b0a`](https://github.com/evo-lua/evo-luvi/commit/2406b0a22328de33e9db0dc83b11adac28f2c3db)] - Move the SIGPIPE handling code to LuaMain",
+				"* \\[[`60a756d`](https://github.com/evo-lua/evo-luvi/commit/60a756d247e8b611e0e0f92075829a3f0766936d)] - Move the CLI spec to the Tests directory",
+				"* \\[[`0938bce`](https://github.com/evo-lua/evo-luvi/commit/0938bcefdf8c3ed11d36f7e414e13329b3a46abc)] - Fix some incorrect API calls in the libuv socket mixins",
+				"* \\[[`1232021`](https://github.com/evo-lua/evo-luvi/commit/1232021553b9678f3cd1a322d62cc2976a6c94ae)] - Add a global extend builtin to cut down on redundant OOP code",
+				"* \\[[`36c6b72`](https://github.com/evo-lua/evo-luvi/commit/36c6b723b30dbdcfda30342dde78c1a05441da29)] - Add support for string buffers to the assertEquals builtin",
+				"* \\[[`ab3663c`](https://github.com/evo-lua/evo-luvi/commit/ab3663cabbda7e4c5ca8c32b4f33f36cfa4100a8)] - Fix compilation warnings in the LPEG submodule",
+				"* \\[[`bb70381`](https://github.com/evo-lua/evo-luvi/commit/bb70381316d7919e35f7d9c85eee8afb0898863d)] - Improve stack traces originating in main.c",
+				"* \\[[`993caa9`](https://github.com/evo-lua/evo-luvi/commit/993caa985c3b80aa9457fd9ebf9be37d08c5c4a2)] - Enable the -g flag globally for generated LuaJIT bytecode objects",
+				"* \\[[`7a621fc`](https://github.com/evo-lua/evo-luvi/commit/7a621fcf144d6678b279158421deb38d4be3893b)] - Add a generator script for the required llhttp-ffi C definitions",
+				"* \\[[`155d033`](https://github.com/evo-lua/evo-luvi/commit/155d0332be7c3afd19548d792f603465de60f526)] - Reorganize the llhttp-ffi and llhttp submodules",
+				"* \\[[`33787c9`](https://github.com/evo-lua/evo-luvi/commit/33787c916739e5bdfd69643a3600999f0af5c4b2)] - Integrate the llhttp-ffi submodule into the source tree",
+				"* \\[[`a5e7b60`](https://github.com/evo-lua/evo-luvi/commit/a5e7b602fa664dc49e6b2b81567c0c52a68a6bd3)] - Update zlib build scripts to also copy zconf.h",
+				"* \\[[`cfb4466`](https://github.com/evo-lua/evo-luvi/commit/cfb44669c41facc7e734213f1be5ddd9d0fe6cc0)] - Update the displayed executable name",
+				"* \\[[`318d353`](https://github.com/evo-lua/evo-luvi/commit/318d3538203e37bbfba4db1618d011c99aa7cd67)] - Remove some unused CMake files",
+				"* \\[[`b2b28b3`](https://github.com/evo-lua/evo-luvi/commit/b2b28b3d30ae6dc695216728e54ffa7688c2ca5b)] - Add a script for exporting the dependency graph",
+				"* \\[[`9e437fb`](https://github.com/evo-lua/evo-luvi/commit/9e437fb1c405469c07e7cf5c2943cd60979f5f2f)] - Fix a typo in the unixbuild-all script",
+				"* \\[[`0263f56`](https://github.com/evo-lua/evo-luvi/commit/0263f56ec0d78bfe60f8584c61f4586237342316)] - Remove the old PCRE1 repository from .gitmodules",
+				"* \\[[`6c103e4`](https://github.com/evo-lua/evo-luvi/commit/6c103e4c3e1dbfa3fba7ff75be45bff860a284a4)] - Remove the broken luvi_renamed module",
+				"* \\[[`3144d3e`](https://github.com/evo-lua/evo-luvi/commit/3144d3eb50aadbbb355930dfb7acafdf4df530f8)] - Add a basic test suite for the PCRE2 library",
+				"* \\[[`f375f15`](https://github.com/evo-lua/evo-luvi/commit/f375f15aed8e5b83a42ea84193523cedf25bbf35)] - Add a basic smoke test for the zlib library",
+				"* \\[[`ddd19dd`](https://github.com/evo-lua/evo-luvi/commit/ddd19dd4d600aca79f24d34b3d285b4f615c411b)] - Add a basic test for the luvi.version export",
+			}
+			assertEquals(commits, expectedCommits)
+		end)
+	end)
+
+	describe("GetChangelogEntry", function()
+		it("should return a table representing the markdown contents for a given version range", function()
+			local changelog = require("changelog")
+			local expectedChanges = changelog["v3.1.0"]
+
+			local expectedChangelogEntry = {
+				versionTag = "v3.1.0",
+				newFeatures = expectedChanges.newFeatures or {},
+				improvements = expectedChanges.improvements or {},
+				breakingChanges = expectedChanges.breakingChanges or {},
+				pullRequests = C_BuildTools.DiscoverMergeCommitsBetween("v3.0.0", "v3.1.0"),
+				contributors = expectedChanges.contributors or {},
+			}
+			local actualChangelogEntry = C_BuildTools.GetChangelogEntry("v3.0.0", "v3.1.0")
+
+			assertEquals(actualChangelogEntry, expectedChangelogEntry)
+		end)
+	end)
+
+	describe("FetchNotableChanges", function()
+		it("should return an empty table if a version tag without notable changes was given", function()
+			local versionTag = "v2.18.0"
+			local notableChanges = C_BuildTools.FetchNotableChanges(versionTag)
+
+			assertEquals(notableChanges, {})
+		end)
+
+		it("should return a table of notable changes if there are any for the given version string", function()
+			local versionTag = "v3.0.0"
+			local notableChanges = C_BuildTools.FetchNotableChanges(versionTag)
+			local expectedChanges = require("changelog")[versionTag]
+
+			assertEquals(notableChanges, expectedChanges)
+		end)
+	end)
+
+	describe("StringifyChangelogContents", function()
+		it(
+			"should return a markdown file without notable changes list if no changelog exists for the given version tag",
+			function()
+				local oldVersion = "v2.17.0"
+				local newVersion = "v2.18.0"
+				local changelogEntry = C_BuildTools.GetChangelogEntry(oldVersion, newVersion)
+
+				local markdownString = C_BuildTools.StringifyChangelogContents(changelogEntry)
+
+				local pullRequestString = C_BuildTools.DiscoverMergeCommitsBetween(oldVersion, newVersion)
+				local expectedMarkdownString = [[
+# v2.18.0
+
+### Pull Requests
+
+]] .. table.concat(pullRequestString, "\n") .. [[
+
+
+#### Contributors (in alphabetical order)
+
+* No external contributors]]
+				assertEquals(markdownString, expectedMarkdownString)
+			end
+		)
+
+		it(
+			"should return a markdown file with notable changes list if a changelog exists for the given version tag",
+			function()
+				local oldVersion = "v3.0.0"
+				local newVersion = "v3.1.0"
+				local changelogEntry = C_BuildTools.GetChangelogEntry(oldVersion, newVersion)
+
+				local markdownString = C_BuildTools.StringifyChangelogContents(changelogEntry)
+
+				local pullRequestString = C_BuildTools.DiscoverMergeCommitsBetween(oldVersion, newVersion)
+				local expectedMarkdownString = [[
+# v3.1.0
+
+### New Features
+
+* A global ``extend`` builtin is now available to complement ``mixin`` with more typical, metatable-based inheritance
+
+### Improvements
+
+* TCP clients and servers now trigger ``TCP_BACKPRESSURE_*`` events based on their internal write buffer status
+* TCP clients and servers now trigger ``TCP_EOF_RECEIVED`` when the connected peer unilaterally closes the socket
+* The runtime now always includes debug symbols for embedded LuaJIT bytecode objects to enable better stack traces
+
+### Breaking Changes
+
+* The standalone [llhttp-ffi](https://github.com/evo-lua/llhttp-ffi) bindings are now integrated with the runtime itself (and will not be maintained independently)
+* The preloaded ``luvi`` library is now called ``runtime`` and has a slightly different exports signature
+
+### Pull Requests
+
+]] .. table.concat(pullRequestString, "\n") .. [[
+
+
+#### Contributors (in alphabetical order)
+
+* No external contributors]]
+				assertEquals(markdownString, expectedMarkdownString)
+			end
+		)
+	end)
+
+	describe("GenerateChangeLog", function()
+		it("should save the last tagged version's changes to the changelog file", function()
+			after(function()
+				C_FileSystem.Delete("CHANGELOG.MD")
+			end)
+
+			local currentHead = C_BuildTools.DiscoverGitVersionTag()
+			local lastVersionTag = C_BuildTools.DiscoverPreviousGitVersionTag()
+			local expectedChanges = C_BuildTools.GetChangelogEntry(lastVersionTag, currentHead)
+			local expectedMarkdownFileContents = C_BuildTools.StringifyChangelogContents(expectedChanges)
+
+			C_BuildTools.GenerateChangeLog()
+
+			local actualMarkdownFileContents = C_FileSystem.ReadFile("CHANGELOG.MD")
+
+			assertEquals(actualMarkdownFileContents, expectedMarkdownFileContents)
 		end)
 	end)
 end)

--- a/changelog.lua
+++ b/changelog.lua
@@ -1,0 +1,27 @@
+local changelog = {
+	["v3.1.0"] = {
+		newFeatures = {
+			"A global ``extend`` builtin is now available to complement ``mixin`` with more typical, metatable-based inheritance",
+		},
+		improvements = {
+			"TCP clients and servers now trigger ``TCP_BACKPRESSURE_*`` events based on their internal write buffer status",
+			"TCP clients and servers now trigger ``TCP_EOF_RECEIVED`` when the connected peer unilaterally closes the socket",
+			"The runtime now always includes debug symbols for embedded LuaJIT bytecode objects to enable better stack traces",
+		},
+		breakingChanges = {
+			"The standalone [llhttp-ffi](https://github.com/evo-lua/llhttp-ffi) bindings are now integrated with the runtime itself (and will not be maintained independently)",
+			"The preloaded ``luvi`` library is now called ``runtime`` and has a slightly different exports signature",
+		},
+	},
+	["v3.0.0"] = {
+		newFeatures = {
+			"The NodeJS [low-level HTTP parser](https://github.com/nodejs/llhttp) is now included in the runtime and made available via the preloaded ``llhttp`` library",
+		},
+		breakingChanges = {
+			"The legacy CMake build system has been replaced with a much simpler one that is based on [Ninja](https://ninja-build.org/) files",
+			"The obsolete ``env`` library has been removed (use the  ``uv`` library for accessing environment variables instead)",
+		},
+	},
+}
+
+return changelog

--- a/create-changelog.lua
+++ b/create-changelog.lua
@@ -1,0 +1,5 @@
+local versionFrom, versionTo = ...
+
+local C_BuildTools = import("Runtime/API/BuildTools/C_BuildTools.lua")
+
+C_BuildTools.GenerateChangeLog(versionFrom, versionTo)


### PR DESCRIPTION
There's a bit of a mess with the tests, the hardcoded changelog stuff should probably move to fixtures. However, not a huge issue for now and I might redesign the entire thing anyway if it turns out to be problematic. Also the build tools are getting a bit bloated, so perhaps the Git-related stuff and the changelog routines need to be extracted?

I'll leave it like this for the time being since it's not too bad, but I get the feeling I'll be cleaning things up eventually...