### PR TITLE
Add an incremental HTTP parser module to the Networking API

### DIFF
--- a/Runtime/API/Networking/C_Networking.lua
+++ b/Runtime/API/Networking/C_Networking.lua
@@ -2,6 +2,7 @@ local C_Networking = {
 	TcpSocket = require("TcpSocket"),
 	TcpServer = require("TcpServer"),
 	TcpClient = require("TcpClient"),
+	IncrementalHttpParser = require("IncrementalHttpParser"),
 	AsyncHandleMixin = require("AsyncHandleMixin"),
 	AsyncStreamMixin = require("AsyncStreamMixin"),
 	AsyncSocketMixin = require("AsyncSocketMixin"),

--- a/Runtime/API/Networking/IncrementalHttpParser.lua
+++ b/Runtime/API/Networking/IncrementalHttpParser.lua
@@ -1,0 +1,100 @@
+local ffi = require("ffi")
+local llhttp = require("llhttp")
+
+local ffi_cast = ffi.cast
+local ffi_string = ffi.string
+
+local tonumber = tonumber
+
+local llhttp_init = llhttp.bindings.llhttp_init
+local llhttp_settings_init = llhttp.bindings.llhttp_settings_init
+local llhttp_execute = llhttp.bindings.llhttp_execute
+local llhttp_get_errno = llhttp.bindings.llhttp_get_errno
+local llhttp_should_keep_alive = llhttp.bindings.llhttp_should_keep_alive
+local llhttp_message_needs_eof = llhttp.bindings.llhttp_message_needs_eof
+local llhttp_get_upgrade = llhttp.bindings.llhttp_get_upgrade
+local llhttp_get_error_reason = llhttp.bindings.llhttp_get_error_reason
+
+local IncrementalHttpParser = {}
+
+function IncrementalHttpParser:Construct()
+	local instance = {
+		state = ffi.new("llhttp_t"),
+		settings = ffi.new("llhttp_settings_t"),
+	}
+
+	llhttp_settings_init(instance.settings)
+	llhttp_init(instance.state, llhttp.PARSER_TYPES.HTTP_BOTH, instance.settings)
+
+	-- Anchor the cdata objects so they don't accidentally get collected and SEGFAULT the runtime
+	instance.http_message = ffi.new("http_message_t")
+	instance.state.data = instance.http_message
+
+	setmetatable(instance, { __index = self })
+
+	return instance
+end
+
+function IncrementalHttpParser:ParseNextChunk(chunk)
+	llhttp_execute(self.state, chunk, #chunk)
+
+	if self.extendedPayloadBuffer then
+		self.extendedPayloadBuffer:commit(self.http_message.extended_payload_buffer.used)
+	end
+
+	return ffi_cast("http_message_t*", self.state.data)
+end
+
+function IncrementalHttpParser:IsOK()
+	local llhttpErrorCode = tonumber(llhttp_get_errno(self.state))
+	local isValidMessage = (llhttpErrorCode == llhttp.ERROR_TYPES.HPE_OK)
+	local isUpgradeRequest = (llhttpErrorCode == llhttp.ERROR_TYPES.HPE_PAUSED_UPGRADE) -- Not really an error...
+	return isValidMessage or isUpgradeRequest
+end
+
+function IncrementalHttpParser:IsExpectingUpgrade()
+	return tonumber(llhttp_get_upgrade(self.state)) == 1
+end
+
+function IncrementalHttpParser:IsExpectingEOF()
+	return tonumber(llhttp_message_needs_eof(self.state)) == 1
+end
+
+function IncrementalHttpParser:ShouldKeepConnectionAlive()
+	return tonumber(llhttp_should_keep_alive(self.state)) == 1
+end
+
+function IncrementalHttpParser:GetLastError()
+	local cdata = llhttp_get_error_reason(self.state)
+
+	if cdata == nil then -- Cannot convert NULL pointer to Lua string
+		return
+	end
+
+	return ffi_string(cdata)
+end
+
+function IncrementalHttpParser:EnableExtendedPayloadBuffer(expectedPayloadSizeInBytes)
+	local message = self.http_message
+
+	local referencePointer, numReservedBytes
+	if self.extendedPayloadBuffer then -- No need to allocate another buffer since it can just be re-used
+		self.extendedPayloadBuffer:reset()
+		referencePointer, numReservedBytes =
+			self.extendedPayloadBuffer:reserve(llhttp.DEFAULT_EXTENDED_PAYLOAD_BUFFER_SIZE_IN_BYTES)
+		message.extended_payload_buffer.ptr = referencePointer
+		message.extended_payload_buffer.size = numReservedBytes
+	else
+		self.extendedPayloadBuffer = llhttp.allocate_extended_payload_buffer(message)
+	end
+
+	message.extended_payload_buffer.used = 0
+end
+
+function IncrementalHttpParser:GetExtendedPayload()
+	return tostring(self.extendedPayloadBuffer)
+end
+
+setmetatable(IncrementalHttpParser, { __call = IncrementalHttpParser.Construct })
+
+return IncrementalHttpParser

--- a/Runtime/Bindings/llhttp_ffi.c
+++ b/Runtime/Bindings/llhttp_ffi.c
@@ -1,27 +1,271 @@
+// #define ENABLE_LLHTTP_CALLBACK_LOGGING 1
+
 #include "llhttp.h"
+#include "llhttp_ffi.h"
 #include "lua.h"
 
-struct static_llhttp_exports_table {
-	void (*llhttp_init)(llhttp_t* parser, llhttp_type_t type, const llhttp_settings_t* settings);
-	void (*llhttp_reset)(llhttp_t* parser);
-	void (*llhttp_settings_init)(llhttp_settings_t* settings);
-	llhttp_errno_t (*llhttp_execute)(llhttp_t* parser, const char* data, size_t len);
-	llhttp_errno_t (*llhttp_finish)(llhttp_t* parser);
-	int (*llhttp_message_needs_eof)(const llhttp_t* parser);
-	int (*llhttp_should_keep_alive)(const llhttp_t* parser);
-	void (*llhttp_pause)(llhttp_t* parser);
-	void (*llhttp_resume)(llhttp_t* parser);
-	void (*llhttp_resume_after_upgrade)(llhttp_t* parser);
-	llhttp_errno_t (*llhttp_get_errno)(const llhttp_t* parser);
-	const char* (*llhttp_get_error_reason)(const llhttp_t* parser);
-	void (*llhttp_set_error_reason)(llhttp_t* parser, const char* reason);
-	const char* (*llhttp_get_error_pos)(const llhttp_t* parser);
-	const char* (*llhttp_errno_name)(llhttp_errno_t err);
-	const char* (*llhttp_method_name)(llhttp_method_t method);
-	void (*llhttp_set_lenient_headers)(llhttp_t* parser, int enabled);
-	void (*llhttp_set_lenient_chunked_length)(llhttp_t* parser, int enabled);
-	void (*llhttp_set_lenient_keep_alive)(llhttp_t* parser, int enabled);
-};
+#include "string.h"
+
+static void DEBUG(const char* message)
+{
+#ifdef ENABLE_LLHTTP_CALLBACK_LOGGING
+	printf("[C] llhttp_ffi: %s\n", message);
+#endif
+}
+
+#define LLHTTP_DATA_CALLBACK(event_name)                                           \
+	int llhttp_##event_name(llhttp_t* parser_state, const char* at, size_t length) \
+	{                                                                              \
+		DEBUG(#event_name);                                                        \
+                                                                                   \
+		return HPE_OK;                                                             \
+	}
+
+#define LLHTTP_INFO_CALLBACK(event_name)            \
+	int llhttp_##event_name(llhttp_t* parser_state) \
+	{                                               \
+		DEBUG(#event_name);                         \
+                                                    \
+		return HPE_OK;                              \
+	}
+
+int llhttp_on_header_value_complete(llhttp_t* parser_state)
+{
+	DEBUG("on_header_value_complete");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	message->num_headers++;
+	return HPE_OK;
+}
+
+int llhttp_on_message_complete(llhttp_t* parser_state)
+{
+	DEBUG("on_message_complete");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	message->is_complete = true;
+	return HPE_OK;
+}
+
+LLHTTP_INFO_CALLBACK(on_chunk_complete)
+LLHTTP_INFO_CALLBACK(on_chunk_header)
+LLHTTP_INFO_CALLBACK(on_message_begin)
+LLHTTP_INFO_CALLBACK(on_headers_complete)
+LLHTTP_INFO_CALLBACK(on_method_complete)
+LLHTTP_INFO_CALLBACK(on_header_field_complete)
+LLHTTP_INFO_CALLBACK(on_chunk_extension_name_complete)
+LLHTTP_INFO_CALLBACK(on_chunk_extension_value_complete)
+LLHTTP_INFO_CALLBACK(on_url_complete)
+
+LLHTTP_DATA_CALLBACK(on_version)
+LLHTTP_DATA_CALLBACK(on_chunk_extension_name)
+LLHTTP_DATA_CALLBACK(on_chunk_extension_value)
+
+int llhttp_on_status_complete(llhttp_t* parser_state)
+{
+	DEBUG("on_status_complete");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	const int status_code = llhttp_get_status_code(parser_state);
+	message->status_code = status_code;
+
+	return HPE_OK;
+}
+
+int llhttp_on_version_complete(llhttp_t* parser_state)
+{
+	DEBUG("on_version_complete");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	message->version_major = llhttp_get_http_major(parser_state);
+	message->version_minor = llhttp_get_http_minor(parser_state);
+
+	return HPE_OK;
+}
+
+int llhttp_on_reset(llhttp_t* parser_state)
+{
+	DEBUG("on_reset");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	// Since we omit safety checks in the callback handlers (for performance reasons), make sure we don't write-fault off the end
+	message->is_complete = false;
+	message->method_length = 0;
+	message->url_length = 0;
+	message->status_length = 0;
+	message->body_length = 0;
+	message->status_code = 0;
+
+	for (uint8_t i = 0; i < message->num_headers; i++) {
+		message->headers[i].key_length = 0;
+		message->headers[i].value_length = 0;
+	}
+	message->num_headers = 0;
+
+	// The LuaJIT string buffer itself should be managed from Lua if resets are needed; it's considered read-only here
+
+	return HPE_OK;
+}
+
+int llhttp_on_url(llhttp_t* parser_state, const char* at, size_t length)
+{
+	DEBUG("on_url");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	if (message->method_length + length > MAX_URL_LENGTH_IN_BYTES) {
+		llhttp_set_error_reason(parser_state, "414 URI Too Long");
+		return HPE_USER;
+	}
+
+	memcpy(message->url + message->url_length, at, length);
+	message->url_length += length;
+
+	return HPE_OK;
+}
+
+int llhttp_on_status(llhttp_t* parser_state, const char* at, size_t length)
+{
+	DEBUG("on_status");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	if (message->status_length + length > MAX_STATUS_LENGTH_IN_BYTES) {
+		llhttp_set_error_reason(parser_state, "Status or reason phrase too long");
+		return HPE_USER;
+	}
+
+	memcpy(message->status + message->status_length, at, length);
+	message->status_length += length;
+
+	return HPE_OK;
+}
+
+int llhttp_on_method(llhttp_t* parser_state, const char* at, size_t length)
+{
+	DEBUG("on_method");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	// Can omit boundary checks here since the parser will never call this for invalid methods
+
+	memcpy(message->method + message->method_length, at, length);
+	message->method_length += length;
+
+	return HPE_OK;
+}
+
+int llhttp_on_header_field(llhttp_t* parser_state, const char* at, size_t length)
+{
+	DEBUG("on_header_field");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	// The count only increases after the current header field is complete
+	const uint8_t last_header_index = message->num_headers;
+	if (last_header_index == MAX_HEADER_COUNT) {
+		llhttp_set_error_reason(parser_state, "Too many headers");
+		return HPE_USER;
+	}
+
+	http_header_t* header = &message->headers[last_header_index];
+
+	if (header->key_length + length > MAX_HEADER_KEY_LENGTH_IN_BYTES) {
+		llhttp_set_error_reason(parser_state, "431 Request Header Fields Too Large");
+		return HPE_USER;
+	}
+
+	memcpy(header->key + header->key_length, at, length);
+	header->key_length += length;
+
+	return HPE_OK;
+}
+
+int llhttp_on_header_value(llhttp_t* parser_state, const char* at, size_t length)
+{
+	DEBUG("on_header_value");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	// The count only increases after the current header field is complete
+	const uint8_t last_header_index = message->num_headers;
+	// Can skip boundary checks since it's handled in on_header_key, so we'll never even get here
+
+	http_header_t* header = &message->headers[last_header_index];
+	if (header->value_length + length > MAX_HEADER_VALUE_LENGTH_IN_BYTES) {
+		llhttp_set_error_reason(parser_state, "431 Request Header Fields Too Large");
+		return HPE_USER;
+	}
+
+	memcpy(header->value + header->value_length, at, length);
+	header->value_length += length;
+
+	return HPE_OK;
+}
+
+inline int try_write_extended_payload(llhttp_t* parser_state, const char* at, size_t length)
+{
+	http_message_t* message = (http_message_t*)parser_state->data; // Can assume this is valid and not NULL here
+
+	if (message->extended_payload_buffer.ptr == NULL) {
+		llhttp_set_error_reason(parser_state, "Message body too large (and extended payloads are disabled)");
+		return HPE_USER;
+	}
+
+	bool has_buffer_enough_space = (message->extended_payload_buffer.size - message->extended_payload_buffer.used) >= length;
+	if (!has_buffer_enough_space) {
+		llhttp_set_error_reason(parser_state, "Message body too large (cannot fit into extended payload buffer)");
+		return HPE_USER;
+	}
+
+	memcpy(message->extended_payload_buffer.ptr, at, length);
+	message->extended_payload_buffer.used += length;
+
+	return HPE_OK;
+}
+
+int llhttp_on_body(llhttp_t* parser_state, const char* at, size_t length)
+{
+	DEBUG("on_body");
+
+	http_message_t* message = (http_message_t*)parser_state->data;
+	if (message == NULL)
+		return HPE_OK;
+
+	bool payload_exceeds_buffer_capacity = message->body_length + length > MAX_BODY_LENGTH_IN_BYTES;
+	if (payload_exceeds_buffer_capacity)
+		return try_write_extended_payload(parser_state, at, length);
+
+	memcpy(message->body + message->body_length, at, length);
+	message->body_length += length;
+
+	return HPE_OK;
+}
 
 #define EXPAND_AS_STRING(text) #text
 #define TOSTRING(text) EXPAND_AS_STRING(text)
@@ -34,16 +278,56 @@ const char* llhttp_get_version_string(void)
 	return LLHTTP_VERSION_STRING;
 }
 
+static void init_settings_with_callback_handlers(llhttp_settings_t* settings)
+{
+	DEBUG("init_settings_with_callback_handlers");
+
+	llhttp_settings_init(settings);
+
+	settings->on_message_begin = llhttp_on_message_begin;
+	settings->on_url = llhttp_on_url;
+	settings->on_status = llhttp_on_status;
+	settings->on_method = llhttp_on_method;
+	settings->on_version = llhttp_on_version;
+	settings->on_header_field = llhttp_on_header_field;
+	settings->on_header_value = llhttp_on_header_value;
+	settings->on_chunk_extension_name = llhttp_on_chunk_extension_name;
+	settings->on_chunk_extension_value = llhttp_on_chunk_extension_value;
+	settings->on_headers_complete = llhttp_on_headers_complete;
+	settings->on_body = llhttp_on_body;
+	settings->on_message_complete = llhttp_on_message_complete;
+	settings->on_url_complete = llhttp_on_url_complete;
+	settings->on_status_complete = llhttp_on_status_complete;
+	settings->on_method_complete = llhttp_on_method_complete;
+	settings->on_version_complete = llhttp_on_version_complete;
+	settings->on_header_field_complete = llhttp_on_header_field_complete;
+	settings->on_header_value_complete = llhttp_on_header_value_complete;
+	settings->on_chunk_extension_name_complete = llhttp_on_chunk_extension_name_complete;
+	settings->on_chunk_extension_value_complete = llhttp_on_chunk_extension_value_complete;
+	settings->on_chunk_header = llhttp_on_chunk_header;
+	settings->on_chunk_complete = llhttp_on_chunk_complete;
+	settings->on_reset = llhttp_on_reset;
+}
+
+size_t llhttp_get_max_url_length() { return MAX_URL_LENGTH_IN_BYTES; }
+size_t llhttp_get_max_status_length() { return MAX_STATUS_LENGTH_IN_BYTES; }
+size_t llhttp_get_max_header_key_length() { return MAX_HEADER_KEY_LENGTH_IN_BYTES; }
+size_t llhttp_get_max_header_value_length() { return MAX_HEADER_VALUE_LENGTH_IN_BYTES; }
+size_t llhttp_get_max_header_count() { return MAX_HEADER_COUNT; }
+size_t llhttp_get_max_body_length() { return MAX_BODY_LENGTH_IN_BYTES; }
+size_t llhttp_get_message_size() { return sizeof(http_message_t); }
+
 void export_llhttp_bindings(lua_State* L)
 {
 	static struct static_llhttp_exports_table llhttp_exports_table;
 	llhttp_exports_table.llhttp_init = llhttp_init;
 	llhttp_exports_table.llhttp_reset = llhttp_reset;
-	llhttp_exports_table.llhttp_settings_init = llhttp_settings_init;
+	llhttp_exports_table.llhttp_settings_init = init_settings_with_callback_handlers;
 	llhttp_exports_table.llhttp_execute = llhttp_execute;
 	llhttp_exports_table.llhttp_finish = llhttp_finish;
 	llhttp_exports_table.llhttp_message_needs_eof = llhttp_message_needs_eof;
 	llhttp_exports_table.llhttp_should_keep_alive = llhttp_should_keep_alive;
+	llhttp_exports_table.llhttp_get_upgrade = llhttp_get_upgrade;
 	llhttp_exports_table.llhttp_pause = llhttp_pause;
 	llhttp_exports_table.llhttp_resume = llhttp_resume;
 	llhttp_exports_table.llhttp_resume_after_upgrade = llhttp_resume_after_upgrade;
@@ -56,7 +340,16 @@ void export_llhttp_bindings(lua_State* L)
 	llhttp_exports_table.llhttp_set_lenient_headers = llhttp_set_lenient_headers;
 	llhttp_exports_table.llhttp_set_lenient_chunked_length = llhttp_set_lenient_chunked_length;
 	llhttp_exports_table.llhttp_set_lenient_keep_alive = llhttp_set_lenient_keep_alive;
+	llhttp_exports_table.llhttp_get_version_string = llhttp_get_version_string;
+	llhttp_exports_table.llhttp_get_max_url_length = llhttp_get_max_url_length;
+	llhttp_exports_table.llhttp_get_max_status_length = llhttp_get_max_status_length;
+	llhttp_exports_table.llhttp_get_max_header_key_length = llhttp_get_max_header_key_length;
+	llhttp_exports_table.llhttp_get_max_header_value_length = llhttp_get_max_header_value_length;
+	llhttp_exports_table.llhttp_get_max_header_count = llhttp_get_max_header_count;
+	llhttp_exports_table.llhttp_get_max_body_length = llhttp_get_max_body_length;
+	llhttp_exports_table.llhttp_get_message_size = llhttp_get_message_size;
 
+	// This wrapper must be bound to the llhttp namespace on initialization from Lua, in place of the dynamic binding (.so/.dll load)
 	lua_getglobal(L, "STATIC_FFI_EXPORTS");
 	lua_pushlightuserdata(L, &llhttp_exports_table);
 	lua_setfield(L, -2, "llhttp");

--- a/Runtime/Bindings/llhttp_ffi.h
+++ b/Runtime/Bindings/llhttp_ffi.h
@@ -1,6 +1,83 @@
 #pragma once
 
+#include "llhttp.h"
 #include "lua.h"
+
+#include <stdbool.h>
+
+// This represents the string buffer's writable area since Lua cannot directly pass the SBuf pointer via FFI (AFAIK), nor the Lua state
+// The FFI bindings just write to it, assuming plenty of space has been reserved ahead of time (somewhat wasteful, but should be safe)
+struct luajit_stringbuffer_reference {
+	size_t size;
+	uint8_t* ptr;
+	size_t used;
+};
+typedef struct luajit_stringbuffer_reference luajit_stringbuffer_reference_t;
+
+#define MAX_URL_LENGTH_IN_BYTES 256
+#define MAX_STATUS_LENGTH_IN_BYTES 256
+#define MAX_HEADER_KEY_LENGTH_IN_BYTES 256
+#define MAX_HEADER_VALUE_LENGTH_IN_BYTES 4096
+#define MAX_HEADER_COUNT 32
+#define MAX_BODY_LENGTH_IN_BYTES 4096
+
+typedef struct {
+	uint8_t key_length;
+	char key[MAX_HEADER_KEY_LENGTH_IN_BYTES];
+	size_t value_length;
+	char value[MAX_HEADER_VALUE_LENGTH_IN_BYTES];
+} http_header_t;
+
+typedef struct http_message {
+	bool is_complete;
+	uint8_t method_length;
+	char method[16];
+	size_t url_length;
+	char url[MAX_URL_LENGTH_IN_BYTES];
+	uint8_t version_major;
+	uint8_t version_minor;
+	int status_code;
+	uint8_t status_length;
+	char status[MAX_STATUS_LENGTH_IN_BYTES];
+	uint8_t num_headers;
+	http_header_t headers[MAX_HEADER_COUNT];
+	size_t body_length;
+	char body[MAX_BODY_LENGTH_IN_BYTES];
+	// We want a continuous memory area (cache locality), but also the flexiliby to stream/buffer large bodies (from Lua) if needed
+	luajit_stringbuffer_reference_t extended_payload_buffer; // Optional feature, enabled on demand by allocating a stringBuffer here
+} http_message_t;
+
+// A thin wrapper for the llhttp API, only needed to expose the statically-linked llhttp symbols to Lua and load them via FFI
+struct static_llhttp_exports_table {
+	void (*llhttp_init)(llhttp_t* parser, llhttp_type_t type, const llhttp_settings_t* settings);
+	void (*llhttp_reset)(llhttp_t* parser);
+	void (*llhttp_settings_init)(llhttp_settings_t* settings);
+	llhttp_errno_t (*llhttp_execute)(llhttp_t* parser, const char* data, size_t len);
+	llhttp_errno_t (*llhttp_finish)(llhttp_t* parser);
+	int (*llhttp_message_needs_eof)(const llhttp_t* parser);
+	int (*llhttp_should_keep_alive)(const llhttp_t* parser);
+	uint8_t (*llhttp_get_upgrade)(llhttp_t* parser);
+	void (*llhttp_pause)(llhttp_t* parser);
+	void (*llhttp_resume)(llhttp_t* parser);
+	void (*llhttp_resume_after_upgrade)(llhttp_t* parser);
+	llhttp_errno_t (*llhttp_get_errno)(const llhttp_t* parser);
+	const char* (*llhttp_get_error_reason)(const llhttp_t* parser);
+	void (*llhttp_set_error_reason)(llhttp_t* parser, const char* reason);
+	const char* (*llhttp_get_error_pos)(const llhttp_t* parser);
+	const char* (*llhttp_errno_name)(llhttp_errno_t err);
+	const char* (*llhttp_method_name)(llhttp_method_t method);
+	void (*llhttp_set_lenient_headers)(llhttp_t* parser, int enabled);
+	void (*llhttp_set_lenient_chunked_length)(llhttp_t* parser, int enabled);
+	void (*llhttp_set_lenient_keep_alive)(llhttp_t* parser, int enabled);
+	const char* (*llhttp_get_version_string)(void);
+	size_t (*llhttp_get_max_url_length)(void);
+	size_t (*llhttp_get_max_status_length)(void);
+	size_t (*llhttp_get_max_header_key_length)(void);
+	size_t (*llhttp_get_max_header_value_length)(void);
+	size_t (*llhttp_get_max_header_count)(void);
+	size_t (*llhttp_get_max_body_length)(void);
+	size_t (*llhttp_get_message_size)(void);
+};
 
 const char* llhttp_get_version_string(void);
 void export_llhttp_bindings(lua_State* L);

--- a/Runtime/LuaEnvironment/init.lua
+++ b/Runtime/LuaEnvironment/init.lua
@@ -29,6 +29,8 @@ function Luvi:LoadExtensionModules()
 	local extensionLoaders = require("extensions")
 	local apiNamespaces = require("namespaces")
 
+	self:InitializeStaticLibraryExports()
+
 	-- Preload primitives (they shouldn't be available globally, but extensions may depend on them)
 	for name, primitiveLoader in pairs(primitives) do
 		package.preload[name] = primitiveLoader()
@@ -43,8 +45,6 @@ function Luvi:LoadExtensionModules()
 	for name, namespaceLoader in pairs(apiNamespaces) do
 		_G[name] = namespaceLoader()
 	end
-
-	self:InitializeStaticLibraryExports()
 end
 
 function Luvi:InitializeStaticLibraryExports()

--- a/Tests/Extensions/llhttp.spec.lua
+++ b/Tests/Extensions/llhttp.spec.lua
@@ -1,4 +1,5 @@
 local llhttp = require("llhttp")
+local ffi = require("ffi")
 
 describe("llhttp", function()
 	it("should be exported as a preloaded package", function()
@@ -6,7 +7,7 @@ describe("llhttp", function()
 	end)
 
 	describe("bindings", function()
-		it("should export all of the llhttp-ffi API", function()
+		it("should export all of the llhttp API", function()
 			local exportedApiSurface = {
 				"llhttp_init",
 				"llhttp_reset",
@@ -33,6 +34,93 @@ describe("llhttp", function()
 				assertEquals(type(llhttp.bindings[functionName]), "cdata", "Should bind function " .. functionName)
 			end
 		end)
+
+		it("should export all of the llhttp-ffi API", function()
+			local exportedApiSurface = {
+				"llhttp_get_version_string",
+				"llhttp_get_max_url_length",
+				"llhttp_get_max_header_key_length",
+				"llhttp_get_max_header_value_length",
+				"llhttp_get_max_header_count",
+				"llhttp_get_max_body_length",
+			}
+
+			for _, functionName in ipairs(exportedApiSurface) do
+				assertEquals(type(llhttp.bindings[functionName]), "cdata", "Should bind function " .. functionName)
+			end
+		end)
+
+		describe("llhttp_get_version_string", function()
+			it("should return a semantic version string", function()
+				local cVersionString = llhttp.bindings.llhttp_get_version_string()
+				local luaVersionString = ffi.string(cVersionString)
+
+				assertEquals(ffi.string(cVersionString), luaVersionString)
+				local major, minor, patch = string.match(luaVersionString, "(%d+).(%d+).(%d+)")
+
+				assertEquals(type(major), "string")
+				assertEquals(type(minor), "string")
+				assertEquals(type(patch), "string")
+			end)
+		end)
+
+		describe("llhttp_get_max_url_length", function()
+			it("should return a number (defined inside the FFI layer)", function()
+				local maxLength = llhttp.bindings.llhttp_get_max_url_length()
+				assertEquals(tonumber(maxLength), 256)
+			end)
+		end)
+
+		describe("llhttp_get_max_status_length", function()
+			it("should return a number (defined inside the FFI layer)", function()
+				local maxLength = llhttp.bindings.llhttp_get_max_status_length()
+				assertEquals(tonumber(maxLength), 256)
+			end)
+		end)
+
+		describe("llhttp_get_max_header_key_length", function()
+			it("should return a number (defined inside the FFI layer)", function()
+				local maxLength = llhttp.bindings.llhttp_get_max_header_key_length()
+				assertEquals(tonumber(maxLength), 256)
+			end)
+		end)
+
+		describe("llhttp_get_max_header_value_length", function()
+			it("should return a number (defined inside the FFI layer)", function()
+				local maxLength = llhttp.bindings.llhttp_get_max_header_value_length()
+				assertEquals(tonumber(maxLength), 4096)
+			end)
+		end)
+
+		describe("llhttp_get_max_header_count", function()
+			it("should return a number (defined inside the FFI layer)", function()
+				local maxLength = llhttp.bindings.llhttp_get_max_header_count()
+				assertEquals(tonumber(maxLength), 32)
+			end)
+		end)
+
+		describe("llhttp_get_max_body_length", function()
+			it("should return a number (defined inside the FFI layer)", function()
+				local maxLength = llhttp.bindings.llhttp_get_max_body_length()
+				assertEquals(tonumber(maxLength), 4096)
+			end)
+		end)
+
+		describe("llhttp_get_message_size", function()
+			-- Since cdefs and c headers aren't auto-synced, probably best to have another failsafe check here to avoid SEGFAULTs
+			it("should be equal to the defined http_message struct size", function()
+				local luaStructSize = ffi.sizeof("http_message_t")
+				local cStructSize = llhttp.bindings.llhttp_get_message_size()
+				assertEquals(luaStructSize, cStructSize)
+			end)
+
+			it("should be small enough to fit into common CPU caches", function()
+				--Ideally, the total size (without extended payload) should be small enough to fit in a modern CPU cache
+				local maxAllowedStructSize = 1024 * 1024 -- i7 L2 cache size
+				local cStructSize = llhttp.bindings.llhttp_get_message_size()
+				assertTrue(cStructSize <= maxAllowedStructSize)
+			end)
+		end)
 	end)
 
 	describe("initialize", function()
@@ -44,6 +132,64 @@ describe("llhttp", function()
 			llhttp.initialize()
 			-- No errors so far? Great... But the bindings should also still be available...
 			assertEquals(type(llhttp.bindings), "cdata")
+		end)
+	end)
+
+	describe("allocate_extended_payload_buffer", function()
+		it("should link a LuaJIT string buffer reference to the passed llhttp_message if one was given", function()
+			local message = ffi.new("http_message_t")
+			assertTrue(ffi.istype("luajit_stringbuffer_reference_t", message.extended_payload_buffer))
+			assertEquals(message.extended_payload_buffer.size, 0)
+			assertEquals(message.extended_payload_buffer.ptr, nil) -- NULL pointer
+			assertEquals(message.extended_payload_buffer.used, 0)
+			llhttp.allocate_extended_payload_buffer(message)
+			assertEquals(message.extended_payload_buffer.size, llhttp.DEFAULT_EXTENDED_PAYLOAD_BUFFER_SIZE_IN_BYTES)
+			assertEquals(message.extended_payload_buffer.used, 0)
+			assertFalse(message.extended_payload_buffer.ptr == nil) -- Must not be a NULL pointer!
+		end)
+
+		it(
+			"should return the linked LuaJIT string buffer alongside the reserved size and its reference pointer",
+			function()
+				local message = ffi.new("http_message_t")
+				local stringBuffer, referencePointer, numReservedBytes =
+					llhttp.allocate_extended_payload_buffer(message)
+				local numBytesUsed = #stringBuffer
+
+				assertEquals(numReservedBytes, llhttp.DEFAULT_EXTENDED_PAYLOAD_BUFFER_SIZE_IN_BYTES)
+				assertEquals(numBytesUsed, 0)
+				assertFalse(referencePointer == nil) -- Must not be a NULL pointer!
+			end
+		)
+	end)
+
+	describe("has_extended_payload_buffer", function()
+		it(
+			"should return true if the given http_message is using an extended payload to store additional body chunks",
+			function()
+				local message = ffi.new("http_message_t")
+				assertFalse(llhttp.has_extended_payload_buffer(message))
+				llhttp.allocate_extended_payload_buffer(message)
+				assertTrue(llhttp.has_extended_payload_buffer(message))
+			end
+		)
+	end)
+
+	describe("version", function()
+		it("should return the embedded llhttp version in semver format", function()
+			local embeddedVersion = llhttp.version()
+			local firstMatchedCharacterIndex, lastMatchedCharacterIndex = string.find(embeddedVersion, "%d+.%d+.%d+")
+
+			assertEquals(firstMatchedCharacterIndex, 1)
+			assertEquals(lastMatchedCharacterIndex, string.len(embeddedVersion))
+			assertEquals(type(string.match(embeddedVersion, "%d+.%d+.%d+")), "string")
+		end)
+
+		it("should be stored in the runtime library", function()
+			-- This probably needs a rework, but for now it will just live here
+			local displayedVersion = require("runtime").libraries.llhttp
+			local embeddedVersion = llhttp.version()
+			assertEquals(displayedVersion, embeddedVersion)
 		end)
 	end)
 end)

--- a/Tests/Runtime/API/Networking/IncrementalHttpParser.spec.lua
+++ b/Tests/Runtime/API/Networking/IncrementalHttpParser.spec.lua
@@ -1,0 +1,1003 @@
+local IncrementalHttpParser = C_Networking.IncrementalHttpParser
+
+local llhttp = require("llhttp")
+local ffi = require("ffi")
+
+local llhttp_get_max_url_length = llhttp.bindings.llhttp_get_max_url_length
+local llhttp_get_max_status_length = llhttp.bindings.llhttp_get_max_status_length
+local llhttp_get_max_header_key_length = llhttp.bindings.llhttp_get_max_header_key_length
+local llhttp_get_max_header_value_length = llhttp.bindings.llhttp_get_max_header_value_length
+local llhttp_get_max_body_length = llhttp.bindings.llhttp_get_max_body_length
+local llhttp_get_max_header_count = llhttp.bindings.llhttp_get_max_header_count
+
+local ffi_string = ffi.string
+
+-- There are two things to consider when passing extremely long inputs: Write-SEGFAULT and read-fault via memcpy (buffer overflow)
+-- The first would crash and therefore fail the tests, but the second might not - so assert that ONLY the passed in bytes are read
+local OVERLY_LONG_URL = string.rep("a", tonumber(llhttp_get_max_url_length()) * 2)
+local OVERLY_LONG_STATUS = string.rep("a", tonumber(llhttp_get_max_status_length()) * 2)
+local OVERLY_LONG_HEADER_KEY = string.rep("a", tonumber(llhttp_get_max_header_key_length()) * 2)
+local OVERLY_LONG_HEADER_VALUE = string.rep("a", tonumber(llhttp_get_max_header_value_length()) * 2)
+local OVERLY_LONG_BODY_STRING = string.rep("a", tonumber(llhttp_get_max_body_length()) * 2)
+local OVERLY_LARGE_HEADERS_STRING = string.rep("Key: Value\r\n", tonumber(llhttp_get_max_header_count()) * 2)
+local OVERLY_LONG_HEADERS = {}
+for i = 1, tonumber(llhttp_get_max_header_count()), 1 do
+	OVERLY_LONG_HEADERS[#OVERLY_LONG_HEADERS + 1] = { key = "Key", key_length = 3, value = "Value", value_length = 5 }
+end
+
+local testCases = {
+	["an invalid message"] = {
+		chunk = "asdf",
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = false,
+		expectedErrorReason = "Invalid method encountered",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 0,
+			version_major = 0,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["an incomplete but otherwise valid request"] = {
+		chunk = "POST /hello",
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = false,
+		message = {
+			is_complete = false,
+			method_length = 4,
+			method = "POST",
+			url_length = 6,
+			url = "/hello",
+			version_minor = 0,
+			version_major = 0,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["an incomplete but otherwise valid response"] = {
+		chunk = "HTTP/1",
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true, -- The client should wait for the server's EOF, which can end the message at any time (RFC2616, 4.4.5)
+		shouldKeepConnectionAlive = false,
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 0,
+			version_major = 0,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a complete (and valid) HTTP/1.1 request"] = {
+		chunk = "GET /hello-world HTTP/1.1\r\n\r\n",
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true, -- Default value for HTTP/1.1
+		message = {
+			is_complete = true,
+			method_length = 3,
+			method = "GET",
+			url_length = 12,
+			url = "/hello-world",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a complete (and valid) HTTP/1.0 request"] = {
+		chunk = "GET /hello-world HTTP/1.0\r\n\r\n",
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = false, -- Default value for HTTP/1.0
+		message = {
+			is_complete = true,
+			method_length = 3,
+			method = "GET",
+			url_length = 12,
+			url = "/hello-world",
+			version_minor = 0,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a complete (and valid) response"] = {
+		chunk = "HTTP/1.1 200 OK\r\n\r\n",
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true,
+		shouldKeepConnectionAlive = false,
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 200,
+			status_length = 2,
+			status = "OK",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a valid WebSockets upgrade request"] = {
+		chunk = "GET /chat HTTP/1.1\r\nHost: example.com:8000\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		isOK = true,
+		isExpectingUpgrade = true,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true,
+		expectedErrorReason = "Pause on CONNECT/Upgrade",
+		message = {
+			is_complete = true,
+			method_length = 3,
+			method = "GET",
+			url_length = 5,
+			url = "/chat",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 5,
+			headers = {
+				{ key_length = 4, key = "Host", value_length = #"example.com:8000", value = "example.com:8000" },
+				{ key_length = #"Upgrade", key = "Upgrade", value_length = #"websocket", value = "websocket" },
+				{ key_length = #"Connection", key = "Connection", value_length = #"Upgrade", value = "Upgrade" },
+				{
+					key_length = #"Sec-WebSocket-Key",
+					key = "Sec-WebSocket-Key",
+					value_length = #"dGhlIHNhbXBsZSBub25jZQ==",
+					value = "dGhlIHNhbXBsZSBub25jZQ==",
+				},
+				{
+					key_length = #"Sec-WebSocket-Version",
+					key = "Sec-WebSocket-Version",
+					value_length = 2,
+					value = "13",
+				},
+			},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a mandatory TLS upgrade request"] = {
+		chunk = "OPTIONS * HTTP/1.1\r\nHost: example.bank.com\r\nUpgrade: TLS/1.0\r\nConnection: Upgrade\r\n\r\n",
+		isOK = true,
+		isExpectingUpgrade = true,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true,
+		expectedErrorReason = "Pause on CONNECT/Upgrade",
+		message = {
+			is_complete = true,
+			method_length = 7,
+			method = "OPTIONS",
+			url_length = 1,
+			url = "*",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 3,
+			headers = {
+				{ key_length = 4, key = "Host", value_length = #"example.bank.com", value = "example.bank.com" },
+				{ key_length = #"Upgrade", key = "Upgrade", value_length = #"TLS/1.0", value = "TLS/1.0" },
+				{ key_length = #"Connection", key = "Connection", value_length = #"Upgrade", value = "Upgrade" },
+			},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["an invalid message that comes after a valid one"] = {
+		chunk = "GET /hello-world HTTP/1.1\r\n\r\nasadfasfthisisnotvalidatall\r\n\r\n",
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true, -- HTTP/1.1 default
+		expectedErrorReason = "Invalid method encountered",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a valid message that comes after an invalid one"] = {
+		chunk = "asadfasfthisisnotvalidatall\r\n\r\nGET /hello-world HTTP/1.1\r\n\r\n",
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = false, -- Due to the initial error state, llhttp discards the second message
+		expectedErrorReason = "Invalid method encountered",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 0,
+			version_major = 0,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["an invalid message that arrives between two valid ones"] = {
+		chunk = "GET /hello-world HTTP/1.1\r\n\r\nasadfasfthisisnotvalidatall\r\n\r\nGET /hello-world HTTP/1.1\r\n\r\n",
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true, -- HTTP/1.1 default
+		expectedErrorReason = "Invalid method encountered",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a valid message that arrives between two invalid ones"] = {
+		chunk = "asadfasfthisisnotvalidatall\r\n\r\nGET /hello-world HTTP/1.1\r\n\r\nasadfasfthisisnotvalidatall\r\n\r\n",
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = false,
+		expectedErrorReason = "Invalid method encountered",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 0,
+			version_major = 0,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a response with Connection: Keep-Alive header"] = {
+		chunk = "HTTP/1.1 204 No Content\r\nConnection: Keep-Alive\r\n\r\n",
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true,
+		message = {
+			is_complete = true,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 204,
+			status_length = 10,
+			status = "No Content",
+			num_headers = 1,
+			headers = {
+				{
+					key_length = #"Connection",
+					key = "Connection",
+					value_length = #"Keep-Alive",
+					value = "Keep-Alive",
+				},
+			},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a valid message that arrives in many different chunks"] = {
+		chunks = {
+			"G",
+			"E",
+			"T /c",
+			"hat H",
+			"TTP/1.1\r",
+			"\nHo",
+			"st: ex",
+			"ample.com:8000\r\nUp",
+			"gra",
+			"de: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+			-- todo add multi chunk body
+		},
+		isOK = true,
+		isExpectingUpgrade = true,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true,
+		expectedErrorReason = "Pause on CONNECT/Upgrade",
+		message = {
+			is_complete = true,
+			method_length = 3,
+			method = "GET",
+			url_length = 5,
+			url = "/chat",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 5,
+			headers = {
+				{ key_length = 4, key = "Host", value_length = #"example.com:8000", value = "example.com:8000" },
+				{ key_length = #"Upgrade", key = "Upgrade", value_length = #"websocket", value = "websocket" },
+				{ key_length = #"Connection", key = "Connection", value_length = #"Upgrade", value = "Upgrade" },
+				{
+					key_length = #"Sec-WebSocket-Key",
+					key = "Sec-WebSocket-Key",
+					value_length = #"dGhlIHNhbXBsZSBub25jZQ==",
+					value = "dGhlIHNhbXBsZSBub25jZQ==",
+				},
+				{
+					key_length = #"Sec-WebSocket-Version",
+					key = "Sec-WebSocket-Version",
+					value_length = 2,
+					value = "13",
+				},
+			},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a valid message that splits the body into different chunks"] = {
+		chunks = {
+			"G",
+			"E",
+			"T /c",
+			"hat H",
+			"TTP/1.1\r",
+			"\nCont",
+			"ent-Length: 11",
+			"\r\n\r\nhell",
+			"o",
+			" kitty\r\n\r\n",
+		},
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true,
+		message = {
+			is_complete = true,
+			method_length = 3,
+			method = "GET",
+			url_length = 5,
+			url = "/chat",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 1,
+			headers = {
+				{ key_length = #"Content-Length", key = "Content-Length", value_length = 2, value = "11" },
+			},
+			body_length = 11,
+			body = "hello kitty",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a request with an url string that is too large to buffer"] = {
+		chunks = {
+			"G",
+			"E",
+			"T /",
+			OVERLY_LONG_URL,
+			" H",
+			"TTP/1.1\r",
+			"\nCont",
+			"ent-Length: 11",
+			"\r\n\r\nhell",
+			"o",
+			" kitty\r\n\r\n",
+		},
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = false,
+		expectedErrorReason = "414 URI Too Long",
+		message = {
+			is_complete = false,
+			method_length = 3,
+			method = "GET",
+			url_length = 1,
+			url = "/",
+			version_minor = 0,
+			version_major = 0,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a response with a status that is too large to buffer"] = {
+		chunks = {
+			"HTTP/1.1 500 ",
+			OVERLY_LONG_STATUS,
+			"\r\n\r\n",
+		},
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true,
+		shouldKeepConnectionAlive = false,
+		expectedErrorReason = "Status or reason phrase too long",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a message with a header key that is too large to buffer"] = {
+		chunks = {
+			"G",
+			"E",
+			"T /",
+			" H",
+			"TTP/1.1\r",
+			"\n",
+			OVERLY_LONG_HEADER_KEY,
+			": 11",
+			"\r\n\r\nhell",
+			"o",
+			" kitty\r\n\r\n",
+		},
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true,
+		expectedErrorReason = "431 Request Header Fields Too Large",
+		message = {
+			is_complete = false,
+			method_length = 3,
+			method = "GET",
+			url_length = 1,
+			url = "/",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a message with a header value that is too large to buffer"] = {
+		chunks = {
+			"GET / HTTP/1.1\r\n",
+			"Origin: ",
+			OVERLY_LONG_HEADER_VALUE,
+			"\r\n\r\n",
+		},
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = false,
+		shouldKeepConnectionAlive = true,
+		expectedErrorReason = "431 Request Header Fields Too Large",
+		message = {
+			is_complete = false,
+			method_length = 3,
+			method = "GET",
+			url_length = 1,
+			url = "/",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 0,
+			status_length = 0,
+			status = "",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a message with a body that is too large to buffer directly"] = {
+		chunks = {
+			"HTTP/1.1 200 OK",
+			"\r\n\r\n",
+			OVERLY_LONG_BODY_STRING,
+		},
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true,
+		shouldKeepConnectionAlive = false,
+		expectedErrorReason = "Message body too large (and extended payloads are disabled)",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 200,
+			status_length = 2,
+			status = "OK",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a message with a body is too large to buffer directly but can be buffered dynamically"] = {
+		chunks = {
+			"HTTP/1.1 200 OK",
+			"\r\n\r\n",
+			OVERLY_LONG_BODY_STRING,
+		},
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true,
+		shouldKeepConnectionAlive = false,
+		extendedPayloadBufferSize = #OVERLY_LONG_BODY_STRING,
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 200,
+			status_length = 2,
+			status = "OK",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = OVERLY_LONG_BODY_STRING, -- TODO remove from other test cases? test ptr, size, used fields?
+		},
+	},
+	["a message with a body is too large to buffer directly and also cannot be buffered dynamically"] = {
+		chunks = {
+			"HTTP/1.1 200 OK",
+			"\r\n\r\n",
+			OVERLY_LONG_BODY_STRING .. OVERLY_LONG_BODY_STRING,
+		},
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true,
+		shouldKeepConnectionAlive = false,
+		extendedPayloadBufferSize = 0, -- Should result in a buffer that is (much) too small (just the default size, basically)
+		expectedErrorReason = "Message body too large (cannot fit into extended payload buffer)",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 200,
+			status_length = 2,
+			status = "OK",
+			num_headers = 0,
+			headers = {},
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = "", -- Should fail to write competely and not just partially
+		},
+	},
+	["a message with too many headers to buffer directly"] = {
+		chunks = {
+			"HTTP/1.1 200 OK\r\n",
+			OVERLY_LARGE_HEADERS_STRING,
+			"\r\n\r\n",
+		},
+		isOK = false,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true,
+		shouldKeepConnectionAlive = false,
+		expectedErrorReason = "Too many headers",
+		message = {
+			is_complete = false,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 200,
+			status_length = 2,
+			status = "OK",
+			num_headers = llhttp_get_max_header_count(),
+			headers = OVERLY_LONG_HEADERS,
+			body_length = 0,
+			body = "",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+	["a message that uses chunked transfor encoding"] = {
+		chunks = {
+			"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n",
+			"7\r\n",
+			"Mozilla\r\n",
+			"11\r\n",
+			"Developer Network\r\n",
+			"0\r\n",
+			"\r\n",
+		},
+		isOK = true,
+		isExpectingUpgrade = false,
+		isExpectingEOF = true,
+		shouldKeepConnectionAlive = false,
+		message = {
+			is_complete = true,
+			method_length = 0,
+			method = "",
+			url_length = 0,
+			url = "",
+			version_minor = 1,
+			version_major = 1,
+			status_code = 200,
+			status_length = 2,
+			status = "OK",
+			num_headers = 2,
+			headers = {
+				{
+					key = "Content-Type",
+					key_length = #"Content-Type",
+					value = "text/plain",
+					value_length = #"text/plain",
+				},
+				{
+					key = "Transfer-Encoding",
+					key_length = #"Transfer-Encoding",
+					value = "chunked",
+					value_length = #"chunked",
+				},
+			},
+			body_length = 24,
+			body = "MozillaDeveloper Network",
+			extended_payload_buffer = {
+				ptr = nil,
+				size = 0,
+				used = 0,
+			},
+		},
+	},
+}
+
+local function parseChunksAndReturnMessage(parser, testCase)
+	local message
+	for index, chunk in ipairs(testCase.chunks or { testCase.chunk }) do
+		message = parser:ParseNextChunk(chunk)
+	end
+	return message
+end
+
+local function assertParserStateMatchesExpectation(parser, testCase)
+	local expectedState = testCase.isOK
+	local actualState = parser:IsOK()
+	assertEquals(actualState, expectedState)
+
+	local expectedErrorString = testCase.expectedErrorReason
+	local actualErrorString = parser:GetLastError()
+	assertEquals(actualErrorString, expectedErrorString)
+end
+
+local function assertBufferedMessageMatchesExpectation(message, testCase)
+	assertEquals(message.is_complete, testCase.message.is_complete)
+
+	if ffi_string(message.method, message.method_length) ~= "HTTP/" then
+		-- llhttp can't do a better job at differentiating between requests and responses for the first few tokens...
+		assertEquals(message.method_length, testCase.message.method_length)
+		assertEquals(ffi_string(message.method, message.method_length), testCase.message.method)
+	end
+	assertEquals(message.status_code, testCase.message.status_code)
+	assertEquals(ffi_string(message.status, message.status_length), testCase.message.status)
+	assertEquals(message.status_length, testCase.message.status_length)
+	assertEquals(ffi_string(message.url, message.url_length), testCase.message.url)
+	assertEquals(message.url_length, testCase.message.url_length)
+	assertEquals(message.version_major, testCase.message.version_major)
+	assertEquals(message.version_minor, testCase.message.version_minor)
+	assertEquals(message.num_headers, testCase.message.num_headers)
+	assertEquals(message.num_headers, #testCase.message.headers)
+
+	for index = 1, message.num_headers, 1 do
+		local cIndex = index - 1
+		if testCase.message.headers and testCase.message.headers[index] then
+			assertEquals(
+				ffi_string(message.headers[cIndex].key, message.headers[cIndex].key_length),
+				testCase.message.headers[index].key
+			)
+			assertEquals(
+				ffi_string(message.headers[cIndex].value, message.headers[cIndex].value_length),
+				testCase.message.headers[index].value
+			)
+		end
+	end
+
+	assertEquals(ffi_string(message.body, message.body_length), testCase.message.body)
+	assertEquals(message.body_length, testCase.message.body_length)
+end
+
+describe("IncrementalHttpParser", function()
+	describe("ParseNextChunk", function()
+		for label, testCase in pairs(testCases) do
+			it("should return the expected result when " .. label .. " was passed", function()
+				local parser = IncrementalHttpParser()
+
+				if testCase.extendedPayloadBufferSize then
+					parser:EnableExtendedPayloadBuffer(testCase.extendedPayloadBufferSize)
+				end
+
+				local message = parseChunksAndReturnMessage(parser, testCase)
+				assertBufferedMessageMatchesExpectation(message, testCase)
+				assertParserStateMatchesExpectation(parser, testCase)
+
+				if testCase.extendedPayloadBufferSize then
+					assertEquals(parser:GetExtendedPayload(), testCase.message.extended_payload_buffer)
+				end
+			end)
+		end
+
+		it("should return a HTTP message with the request details", function()
+			local parser = IncrementalHttpParser()
+			local chunk =
+				"GET / HTTP/1.1\r\nOrigin: example.org\r\nConnection: close\r\nContent-Length: 5\r\n\r\nhello\r\n\r\n"
+			local message = parser:ParseNextChunk(chunk)
+			assertEquals(ffi_string(message.method), "GET")
+			assertEquals(ffi_string(message.url), "/")
+			assertEquals(tonumber(message.version_major), 1)
+			assertEquals(tonumber(message.version_minor), 1)
+			assertEquals(tonumber(message.num_headers), 3)
+			assertEquals(ffi_string(message.headers[0].key), "Origin")
+			assertEquals(ffi_string(message.headers[0].value), "example.org")
+			assertEquals(ffi_string(message.headers[1].key), "Connection")
+			assertEquals(ffi_string(message.headers[1].value), "close")
+			assertEquals(ffi_string(message.headers[2].key), "Content-Length")
+			assertEquals(ffi_string(message.headers[2].value), "5")
+			assertEquals(ffi_string(message.body), "hello")
+		end)
+
+		it("should re-use the external payload buffer once it has been enabled", function()
+			local parser = IncrementalHttpParser()
+			local maxBodySize = tonumber(llhttp_get_max_body_length())
+
+			for i = 0, 100, 1 do
+				local isEven = (i % 2 == 0)
+				local payloadChar = isEven and "e" or "o" -- Alternate to make sure the buffer is actually written to each time
+				local longPayload = string.rep(payloadChar, maxBodySize * 2)
+				local chunk = "GET / HTTP/1.1\r\nContent-Length: " .. #longPayload .. "\r\n\r\n" .. longPayload
+
+				-- Not sure this design is it, but for now we can at least be sure the parser doesn't segfault
+				parser:EnableExtendedPayloadBuffer(maxBodySize * 10)
+				parser:ParseNextChunk(chunk)
+				assertEquals(parser:GetLastError(), nil)
+				assertEquals(parser:GetExtendedPayload(), longPayload)
+			end
+		end)
+	end)
+
+	describe("IsExpectingUpgrade", function()
+		for label, testCase in pairs(testCases) do
+			local expectedState = testCase.isExpectingUpgrade
+			it("should return " .. tostring(expectedState) .. " after parsing " .. label, function()
+				local parser = IncrementalHttpParser()
+
+				parseChunksAndReturnMessage(parser, testCase)
+
+				local actualState = parser:IsExpectingUpgrade()
+				assertEquals(actualState, expectedState)
+			end)
+		end
+	end)
+
+	describe("IsExpectingEOF", function()
+		for label, testCase in pairs(testCases) do
+			local expectedState = testCase.isExpectingEOF
+			it("should return " .. tostring(expectedState) .. " after parsing " .. label, function()
+				local parser = IncrementalHttpParser()
+
+				parseChunksAndReturnMessage(parser, testCase)
+
+				local actualState = parser:IsExpectingEOF()
+				assertEquals(actualState, expectedState)
+			end)
+		end
+	end)
+
+	describe("ShouldKeepConnectionAlive", function()
+		for label, testCase in pairs(testCases) do
+			local expectedState = testCase.shouldKeepConnectionAlive
+			it("should return " .. tostring(expectedState) .. " after parsing " .. label, function()
+				local parser = IncrementalHttpParser()
+
+				parseChunksAndReturnMessage(parser, testCase)
+
+				local actualState = parser:ShouldKeepConnectionAlive()
+				assertEquals(actualState, expectedState)
+			end)
+		end
+	end)
+end)

--- a/deps/llhttp.lua
+++ b/deps/llhttp.lua
@@ -315,6 +315,13 @@ local llhttp = {
 	]] ..
 	-- These are copied from the runtime's FFI bindings (to access statically-linked llhttp exports via FFI)
 	[[
+		struct luajit_stringbuffer_reference {
+			size_t size;
+			uint8_t* ptr;
+			size_t used;
+		};
+		typedef struct luajit_stringbuffer_reference luajit_stringbuffer_reference_t;
+
 		struct static_llhttp_exports_table {
 			void (*llhttp_init)(llhttp_t* parser, llhttp_type_t type, const llhttp_settings_t* settings);
 			void (*llhttp_reset)(llhttp_t* parser);
@@ -323,6 +330,7 @@ local llhttp = {
 			llhttp_errno_t (*llhttp_finish)(llhttp_t* parser);
 			int (*llhttp_message_needs_eof)(const llhttp_t* parser);
 			int (*llhttp_should_keep_alive)(const llhttp_t* parser);
+			uint8_t  (*llhttp_get_upgrade)(llhttp_t* parser);
 			void (*llhttp_pause)(llhttp_t* parser);
 			void (*llhttp_resume)(llhttp_t* parser);
 			void (*llhttp_resume_after_upgrade)(llhttp_t* parser);
@@ -335,8 +343,46 @@ local llhttp = {
 			void (*llhttp_set_lenient_headers)(llhttp_t* parser, int enabled);
 			void (*llhttp_set_lenient_chunked_length)(llhttp_t* parser, int enabled);
 			void (*llhttp_set_lenient_keep_alive)(llhttp_t* parser, int enabled);
+			const char* (*llhttp_get_version_string)(void);
+			size_t (*llhttp_get_max_url_length)(void);
+			size_t (*llhttp_get_max_status_length)(void);
+			size_t (*llhttp_get_max_header_key_length)(void);
+			size_t (*llhttp_get_max_header_value_length)(void);
+			size_t (*llhttp_get_max_header_count)(void);
+			size_t (*llhttp_get_max_body_length)(void);
+			size_t (*llhttp_get_message_size)(void);
 		};
-	]],
+	]]
+	..
+	[[
+
+		typedef struct {
+			uint8_t key_length;
+			char key[256];
+			size_t value_length;
+			char value[4096];
+		} http_header_t;
+
+		typedef struct http_message {
+			bool is_complete;
+			uint8_t method_length;
+			char method[16];
+			size_t url_length;
+			char url[256];
+			uint8_t version_major;
+			uint8_t version_minor;
+			int status_code;
+			uint8_t status_length;
+			char status[256];
+			uint8_t num_headers;
+			http_header_t headers[32];
+			size_t body_length;
+			char body[4096];
+			luajit_stringbuffer_reference_t extended_payload_buffer;
+		};
+		typedef struct http_message http_message_t;
+
+		]],
 	PARSER_TYPES = {
 		HTTP_BOTH = 0,
 		HTTP_REQUEST = 1,
@@ -418,6 +464,15 @@ local llhttp = {
 		HTTP_FLUSH = 45
 	},
 	SHARED_OBJECT_NAME = isWindows and "llhttp.dll" or "./libllhttp.so",
+	DEFAULT_EXTENDED_PAYLOAD_BUFFER_SIZE_IN_BYTES = 8 * 1024, -- Not a hard limit, just enough to avoid too many re-allocations
+
+	-- Sane defaults, but they may have to be adjusted for more specialized use cases or to balance RAM usage per client
+	MAX_URL_LENGTH_IN_BYTES = 1024,
+	MAX_REASON_PHRASE_LENGTH_IN_BYTES = 256,
+	MAX_NUM_HEADER_KEYVALUE_PAIRS = 32,
+	MAX_HEADER_FIELD_LENGTH_IN_BYTES = 64,
+	MAX_HEADER_VALUE_LENGTH_IN_BYTES = 256,
+	MAX_BODY_LENGTH_IN_BYTES = 1024 * 1024, -- Large messages should likely use the streaming mode and write to temporary files instead
 }
 
 -- In order to use the same bindings when statically linking the API (with a lightuserdata wrapper), defer loading
@@ -434,6 +489,31 @@ function llhttp.initialize()
 
 	llhttp.initialized = true
 
+end
+
+local buffer = require("string.buffer")
+
+function llhttp.allocate_extended_payload_buffer(httpMessageStruct)
+	local stringBuffer = buffer.new(llhttp.DEFAULT_EXTENDED_PAYLOAD_BUFFER_SIZE_IN_BYTES)
+	local referencePointer, reservedBufferSizeInBytes = stringBuffer:reserve(0) -- Already implicitly reserved via the constructor call
+	httpMessageStruct.extended_payload_buffer.ptr = referencePointer
+	httpMessageStruct.extended_payload_buffer.size = reservedBufferSizeInBytes
+	return stringBuffer, referencePointer, reservedBufferSizeInBytes
+end
+
+function llhttp.has_extended_payload_buffer(message)
+	local hasReservedBytes = message.extended_payload_buffer.size >  0
+	local isReferenceNullPointer = message.extended_payload_buffer.ptr == nil
+	return hasReservedBytes and not isReferenceNullPointer
+end
+
+local ffi_string = ffi.string
+local format = format
+local tonumber = tonumber
+
+function llhttp.version()
+	local llhttpVersion = llhttp.bindings.llhttp_get_version_string()
+	return ffi.string(llhttpVersion)
 end
 
 return llhttp

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -49,6 +49,7 @@ local EvoBuildTarget = {
 		"Runtime/API/FileSystem/C_FileSystem.lua",
 		"Runtime/API/Testing/Scenario.lua",
 		"Runtime/API/Testing/TestSuite.lua",
+		"Runtime/API/Networking/IncrementalHttpParser.lua",
 		"Runtime/API/Networking/TcpSocket.lua",
 		"Runtime/API/Networking/TcpClient.lua",
 		"Runtime/API/Networking/TcpServer.lua",

--- a/test.lua
+++ b/test.lua
@@ -9,6 +9,7 @@ local testCases = {
 	"Tests/Runtime/API/FileSystem/C_FileSystem.spec.lua",
 	"Tests/Runtime/API/Testing/Scenario.spec.lua",
 	"Tests/Runtime/API/Testing/TestSuite.spec.lua",
+	"Tests/Runtime/API/Networking/IncrementalHttpParser.spec.lua",
 	"Tests/Runtime/API/Networking/C_Networking.spec.lua",
 	"Tests/Primitives/extend.spec.lua",
 	"Tests/Primitives/format.spec.lua",


### PR DESCRIPTION
The test cases likely could benefit from a better organization, and the extended payload logic is very rudimentary. But for the time being it's good enough and should fulfill all the requirements, so that improvements can be made over time as they're needed.